### PR TITLE
Added utility to calculate EAN barcode type parity bit #56

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 psd
 thumb
 *.log
+package-lock.json

--- a/barcode.js
+++ b/barcode.js
@@ -1,0 +1,21 @@
+'use strict';
+
+function getParityBit(code, type) {
+  switch(type) {
+    case 'EAN13':
+    case 'EAN8': {
+      var parity = 0, reversedCode = code.split('').reverse().join('');
+      for (var counter = 0; counter < reversedCode.length; counter += 1) {
+        parity += parseInt(reversedCode.charAt(counter), 10) * Math.pow(3, ((counter + 1) % 2));
+      }
+      return String((10 - (parity % 10)) % 10);
+    }
+    default: {
+      return '';
+    }
+  }
+}
+
+module.exports = {
+  getParityBit,
+};

--- a/examples/barcode.js
+++ b/examples/barcode.js
@@ -1,0 +1,20 @@
+'use strict';
+const escpos = require('../');
+
+const device  = new escpos.USB();
+
+const printer = new escpos.Printer(device);
+
+device.open(function() {
+  printer
+  .font('a')
+  .align('ct')
+  .size(1, 1)
+  .text('EAN13 barcode example')
+  .barcode('123456789012', 'EAN13') // code length 12
+  .barcode('109876543210') // default type 'EAN13'
+  .barcode('7654321', 'EAN8') // The EAN parity bit is automatically added.
+  .cut()
+  .cut()
+  .close();
+});

--- a/examples/index.js
+++ b/examples/index.js
@@ -16,7 +16,7 @@ device.open(function(){
   .size(1, 1)
   .text('The quick brown fox jumps over the lazy dog')
   .text('敏捷的棕色狐狸跳过懒狗')
-  .barcode('12345678', 'EAN8')
+  .barcode('1234567', 'EAN8')
   .qrimage('https://github.com/song940/node-escpos', function(err){
     this.cut();
     this.close();


### PR DESCRIPTION
## Background

EAN bar codes have parity bits by default.
If the parity bit is not correct, the barcode scanner will not recognize it.

For example, for EAN-13 only 12 characters can be specified by the user and the last 13th bit must be calculated as parity bit.

This can be found on Wikipedia. (Https://en.wikipedia.org/wiki/International_Article_Number#Calculation_of_checksum_digit)

## Commit Details
- If escpos provides the barcode function, I think you also need the code to calculate the parity bit. So I added the part of the `Printer.prototype.barcode` function that calculates the parity bit of the EAN type barcode.
- For EAN-13, if `code.length` is not 12, it is meaningless. So I added an exception for this. EAN-8 also added exception handling when `code.length` is not 7.
- I created a new `./barcode.js` file. The `getParityBit (code, type)` function is defined inside. I only looked at the EAN type, so I made it easy to add other types.
- reduced the barcode length of `./example/index.js` from 8 to 7.
- added a new `./example/barcode.js` file.
- I'm using `Npm v5` now. `package-lock.json` file is automatically generated, but it is considered unnecessary for this project and added to `.gitignore` (I tried not to use the latest JavaScript function as much as possible.)

## Testing
- I tried to add the test code but I gave up because I could not check the data inside the buffer. However, I did some tests myself and it worked normally.
- The barcode containing the calculated parity bits was recognized normally by the barcode scanner.

Feedback is needed.
Thanks.