### PR TITLE
Revision on Generation of the Barcode on types CODE128 and CODE93

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -151,8 +151,8 @@ _.BARCODE_FORMAT = {
     4: '\x1d\x77\x05',
     5: '\x1d\x77\x06',
   },
-  BARCODE_HEIGHT_DEFAULT  : '\x1d\x77\x64', // Barcode height default:100
-  BARCODE_WIDTH_DEFAULT   : '\x1d\x77\x03', // Barcode width default:3
+  BARCODE_HEIGHT_DEFAULT  : '\x1d\x66\x64', // Barcode height default:100
+  BARCODE_WIDTH_DEFAULT   : '\x1d\x77\x01', // Barcode width default:1
 
   BARCODE_UPC_A   : '\x1d\x6b\x00' , // Barcode type UPC-A
   BARCODE_UPC_E   : '\x1d\x6b\x01' , // Barcode type UPC-E
@@ -161,8 +161,8 @@ _.BARCODE_FORMAT = {
   BARCODE_CODE39  : '\x1d\x6b\x04' , // Barcode type CODE39
   BARCODE_ITF     : '\x1d\x6b\x05' , // Barcode type ITF
   BARCODE_NW7     : '\x1d\x6b\x06' , // Barcode type NW7
-  BARCODE_CODE93  : '\x1d\x6b\x07' , // Barcode type CODE93
-  BARCODE_CODE128 : '\x1d\x6b\x08' , // Barcode type CODE128
+  BARCODE_CODE93  : '\x1d\x6b\x48' , // Barcode type CODE93
+  BARCODE_CODE128 : '\x1d\x6b\x49' , // Barcode type CODE128
 };
 
 /**

--- a/printer.js
+++ b/printer.js
@@ -290,7 +290,7 @@ Printer.prototype.hardware = function(hw){
  */
 Printer.prototype.barcode = function(code, type, width, height, position, font){
   type = type || 'EAN13'; // default type is EAN13, may a good choice ?
-  var convertCode = String(code), parityBit = '', codeLengh = '';
+  var convertCode = String(code), parityBit = '', codeLength = '';
   if(typeof type === 'undefined' || type === null){
     throw new TypeError('barcode type is required');
   }

--- a/printer.js
+++ b/printer.js
@@ -290,7 +290,7 @@ Printer.prototype.hardware = function(hw){
  */
 Printer.prototype.barcode = function(code, type, width, height, position, font){
   type = type || 'EAN13'; // default type is EAN13, may a good choice ?
-  var convertCode = String(code), parityBit = '';
+  var convertCode = String(code), parityBit = '', codeLengh = '';
   if(typeof type === 'undefined' || type === null){
     throw new TypeError('barcode type is required');
   }
@@ -322,7 +322,10 @@ Printer.prototype.barcode = function(code, type, width, height, position, font){
   if (type === 'EAN13' || type === 'EAN8') {
     parityBit = utils.getParityBit(code);
   }
-  this.buffer.write(code + parityBit);
+  if(type == 'CODE128' || type == 'CODE93'){
+    codeLength = utils.getCodeLenght(code);
+  }
+  this.buffer.write(codeLength + code + parityBit + '\x00');
   return this;
 };
 

--- a/printer.js
+++ b/printer.js
@@ -323,7 +323,7 @@ Printer.prototype.barcode = function(code, type, width, height, position, font){
     parityBit = utils.getParityBit(code);
   }
   if(type == 'CODE128' || type == 'CODE93'){
-    codeLength = utils.getCodeLenght(code);
+    codeLength = utils.codeLength(code);
   }
   this.buffer.write(codeLength + code + parityBit + '\x00');
   return this;

--- a/utils.js
+++ b/utils.js
@@ -11,6 +11,6 @@ exports.getParityBit = function (str) {
 };
 
 exports.codeLength = function (str) {
-  let buff = Buffer.from((barcode.length).toString(16), 'hex');
+  let buff = Buffer.from((str.length).toString(16), 'hex');
   return buff.toString();
 }

--- a/utils.js
+++ b/utils.js
@@ -2,10 +2,15 @@
  * [getParityBit description]
  * @return {[type]} [description]
  */
-exports.getParityBit = function (str){
+exports.getParityBit = function (str) {
   var parity = 0, reversedCode = str.split('').reverse().join('');
   for (var counter = 0; counter < reversedCode.length; counter += 1) {
     parity += parseInt(reversedCode.charAt(counter), 10) * Math.pow(3, ((counter + 1) % 2));
   }
   return String((10 - (parity % 10)) % 10);
 };
+
+exports.codeLength = function (str) {
+  let buff = Buffer.from((barcode.length).toString(16), 'hex');
+  return buff.toString();
+}


### PR DESCRIPTION
According with the Manual of Programmer of the language ESC/POS, some data send to printer was wrong on the archives that I changed.

This errors caused various problems when printing barcodes on this printers. 

In my case this changes corrected the problems and now the printer works as expected.

**Corrections on Printing all types of Barcodes:**

1. Added the hex character '\x00' on the end of the data, to inform the printer that de barcode has ended.

2. Resized default witdth of barcodes to 1 by default, because when barcode is too big I got wrong characters on printing, instead of the barcode.

3. Changed the Hex char that inform the printer the height of the barcode.

**Corrections on Printing of Barcodes: CODE128 and CODE93:** 

1. Added a function to calculate the size of the barcode data, and send to the printer, so the printer will know the size of this Barcode types.

2. Changed the Hex char that identify the type of the 2 barcodes.