### PR TITLE
Add support for Qsprinter. Minor bug fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Raises `CashDrawerError()``
 + [Jose Vera](https://github.com/jor3l)
 + [Sébastien Vidal](https://github.com/Psychopoulet)
 + [Yu Yongwoo](https://github.com/uyu423)
++ [Attawit Kittikrairit](https://github.com/atton16)
 
 ----
 

--- a/commands.js
+++ b/commands.js
@@ -145,7 +145,7 @@ _.MODEL = {
         CMD: '\x1b\x23\x23\x51\x50\x49\x58',
         MIN: 1,
         MAX: 24,
-        DEFAULT: 24,
+        DEFAULT: 12,
       },
       VERSION: {
         CMD: '\x1d\x28\x6b\x03\x00\x31\x43',

--- a/commands.js
+++ b/commands.js
@@ -128,6 +128,57 @@ _.TEXT_FORMAT = {
 };
 
 /**
+ * Qsprinter-compatible
+ * Added by Attawit Kittikrairit
+ * [MODEL Model-specific commands]
+ * @type {Object}
+ */
+_.MODEL = {
+  QSPRINTER: {
+    BARCODE_MODE: {
+      ON  : '\x1d\x45\x43\x01' , // Barcode mode on
+      OFF : '\x1d\x45\x43\x00' , // Barcode mode off
+    },
+    BARCODE_HEIGHT_DEFAULT: '\x1d\x68\xA2', // Barcode height default:162
+    CODE2D_FORMAT: {
+      PIXEL_SIZE: {
+        CMD: '\x1b\x23\x23\x51\x50\x49\x58',
+        MIN: 1,
+        MAX: 24,
+        DEFAULT: 24,
+      },
+      VERSION: {
+        CMD: '\x1d\x28\x6b\x03\x00\x31\x43',
+        MIN: 1,
+        MAX: 16,
+        DEFAULT: 3,
+      },
+      LEVEL: {
+        CMD: '\x1d\x28\x6b\x03\x00\x31\x45',
+        OPTIONS: {
+          L: 48,
+          M: 49,
+          Q: 50,
+          H: 51,
+        }
+      },
+      LEN_OFFSET: 3,
+      SAVEBUF: {
+        // Format: CMD_P1{LEN_2BYTE}CMD_P2{DATA}
+        // DATA Max Length: 256*256 - 3 (65533)
+        CMD_P1: '\x1d\x28\x6b',
+        CMD_P2: '\x31\x50\x30',
+      },
+      PRINTBUF: {
+        // Format: CMD_P1{LEN_2BYTE}CMD_P2
+        CMD_P1: '\x1d\x28\x6b',
+        CMD_P2: '\x31\x51\x30',
+      }
+    },
+  },
+};
+
+/**
  * [BARCODE_FORMAT Barcode format]
  * @type {Object}
  */
@@ -151,7 +202,7 @@ _.BARCODE_FORMAT = {
     4: '\x1d\x77\x05',
     5: '\x1d\x77\x06',
   },
-  BARCODE_HEIGHT_DEFAULT  : '\x1d\x66\x64', // Barcode height default:100
+  BARCODE_HEIGHT_DEFAULT  : '\x1d\x68\x64', // Barcode height default:100
   BARCODE_WIDTH_DEFAULT   : '\x1d\x77\x01', // Barcode width default:1
 
   BARCODE_UPC_A   : '\x1d\x6b\x00' , // Barcode type UPC-A

--- a/examples/qs_barcode.js
+++ b/examples/qs_barcode.js
@@ -1,0 +1,20 @@
+'use strict';
+const escpos = require('../');
+
+const device  = new escpos.USB(0x0485, 0x7541);
+
+const printer = new escpos.Printer(device);
+
+device.open(function() {
+  printer
+  .model('qsprinter')
+  .font('a')
+  .align('ct')
+  .size(1, 1)
+  .encode('tis620')
+  .text('EAN13 barcode example')
+  .barcode('123456789012', 'EAN13') // code length 12
+  // .barcode('109876543210') // default type 'EAN13'
+  // .barcode('7654321', 'EAN8') // The EAN parity bit is automatically added.
+  .close();
+});

--- a/examples/qs_qrcode.js
+++ b/examples/qs_qrcode.js
@@ -1,0 +1,22 @@
+'use strict';
+const escpos = require('../');
+
+const device  = new escpos.USB(0x0485, 0x7541);
+
+const printer = new escpos.Printer(device);
+
+device.open(function() {
+  printer
+  .model('qsprinter')
+  .font('a')
+  .align('ct')
+  .size(1, 1)
+  .encode('utf8')
+  .text('QR code example')
+  // .qrcodeqs('http://agriex.market')
+  .qrcode('ทดสอบ')
+  // .barcode('123456789012', 'EAN13') // code length 12
+  // .barcode('109876543210') // default type 'EAN13'
+  // .barcode('7654321', 'EAN8') // The EAN parity bit is automatically added.
+  .close();
+});

--- a/examples/qs_text.js
+++ b/examples/qs_text.js
@@ -1,0 +1,28 @@
+'use strict';
+const escpos = require('../');
+
+const device  = new escpos.USB(0x0485, 0x7541);
+// const device  = new escpos.Network('localhost');
+// const device  = new escpos.Serial('/dev/usb/lp0');
+const printer = new escpos.Printer(device);
+
+device.open(function(err){
+
+  printer
+  .model('qsprinter')
+  .font('a')
+  .align('ct')
+  .style('bu')
+  .size(1, 1)
+  .encode('tis620')
+  .text('The quick brown fox jumps over the lazy dog')
+  .text('สวัสดีภาษาไทย')
+  .close();
+  // .text('敏捷的棕色狐狸跳过懒狗')
+  // .barcode('1234567', 'EAN8')
+  // .qrimage('https://github.com/song940/node-escpos', function(err){
+  //   this.cut();
+  //   this.close();
+  // });
+
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "contributors": [
     "Jose Vera <hola@jose.com.co>",
     "Sébastien Vidal <Psychopoulet@GitHub.com>",
-    "Yu Yongwoo <uyu423@gmail.com>"
+    "Yu Yongwoo <uyu423@gmail.com>",
+    "Attawit Kittikrairit <atton16@gmail.com>"
   ],
   "license": "MIT",
   "bugs": {

--- a/printer.js
+++ b/printer.js
@@ -389,6 +389,7 @@ Printer.prototype.qrcode = function(code, version, level, size){
     if(dataRaw.length < 1 && dataRaw.length > 2710){
       throw new Error('Invalid code length in byte. Must be between 1 and 2710');
     }
+    
     // Set pixel size
     if(!size || (size && typeof size !== 'number'))
       size = _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.DEFAULT;
@@ -402,9 +403,9 @@ Printer.prototype.qrcode = function(code, version, level, size){
     // Set version
     if(!version || (version && typeof version !== 'number'))
       version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.DEFAULT;
-    else if(size && size < _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MIN)
+    else if(version && version < _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MIN)
       version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MIN;
-    else if(size && size > _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MAX)
+    else if(version && version > _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MAX)
       version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MAX;
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.CMD);
     this.buffer.writeUInt8(version);

--- a/printer.js
+++ b/printer.js
@@ -24,6 +24,7 @@ function Printer(adapter){
   this.adapter = adapter;
   this.buffer = new Buffer();
   this.encoding = 'GB18030';
+  this._model = null;
 };
 
 Printer.create = function(device){
@@ -35,6 +36,21 @@ Printer.create = function(device){
  * Printer extends EventEmitter
  */
 util.inherits(Printer, EventEmitter);
+
+/**
+ * Set printer model to recognize model-specific commands.
+ * Supported models: [ null, 'qsprinter' ]
+ * 
+ * For generic printers, set model to null
+ * 
+ * [function set printer model]
+ * @param  {[String]}  model [mandatory]
+ * @return printer instance
+ */
+Printer.prototype.model = function(_model) {
+  this._model = _model;
+  return this;
+};
 
 /**
  * Fix bottom margin
@@ -304,7 +320,12 @@ Printer.prototype.barcode = function(code, type, width, height, position, font){
   if (type === 'EAN8' && convertCode.length != 7) {
     throw new Error('EAN8 Barcode type requires code length 7');
   }
-  if(width >= 2 || width <= 6){
+  if(this._model === 'qsprinter'){
+    this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.ON);
+  }
+  if(this._model === 'qsprinter'){
+    // qsprinter has no BARCODE_WIDTH command (as of v7.5)
+  }else if(width >= 2 || width <= 6){
     this.buffer.write(_.BARCODE_FORMAT.BARCODE_WIDTH[width]);
   }else{
     this.buffer.write(_.BARCODE_FORMAT.BARCODE_WIDTH_DEFAULT);
@@ -312,11 +333,19 @@ Printer.prototype.barcode = function(code, type, width, height, position, font){
   if(height >=1  || height <= 255){
     this.buffer.write(_.BARCODE_FORMAT.BARCODE_HEIGHT(height));
   }else{
-    this.buffer.write(_.BARCODE_FORMAT.BARCODE_HEIGHT_DEFAULT);
+    if(this._model === 'qsprinter'){
+      this.buffer.write(_.MODEL.QSPRINTER.BARCODE_HEIGHT_DEFAULT);
+    }else{
+      this.buffer.write(_.BARCODE_FORMAT.BARCODE_HEIGHT_DEFAULT);
+    }
   }
-  this.buffer.write(_.BARCODE_FORMAT[
-    'BARCODE_FONT_' + (font || 'A').toUpperCase()
-  ]);
+  if(this._model === 'qsprinter'){
+    // Qsprinter has no barcode font
+  }else{
+    this.buffer.write(_.BARCODE_FORMAT[
+      'BARCODE_FONT_' + (font || 'A').toUpperCase()
+    ]);
+  }
   this.buffer.write(_.BARCODE_FORMAT[
     'BARCODE_TXT_' + (position || 'BLW').toUpperCase()
   ]);
@@ -330,6 +359,9 @@ Printer.prototype.barcode = function(code, type, width, height, position, font){
     codeLength = utils.codeLength(code);
   }
   this.buffer.write(codeLength + code + parityBit + '\x00');
+  if(this._model === 'qsprinter'){
+    this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.OFF);
+  }
   return this;
 };
 
@@ -342,15 +374,64 @@ Printer.prototype.barcode = function(code, type, width, height, position, font){
  * @return {[type]}         [description]
  */
 Printer.prototype.qrcode = function(code, version, level, size){
-  this.buffer.write(_.CODE2D_FORMAT.TYPE_QR);
-  this.buffer.write(_.CODE2D_FORMAT.CODE2D);
-  this.buffer.writeUInt8(version || 3);
-  this.buffer.write(_.CODE2D_FORMAT[
-    'QR_LEVEL_' + (level || 'L').toUpperCase()
-  ]);
-  this.buffer.writeUInt8(size || 6);
-  this.buffer.writeUInt16LE(code.length);
-  this.buffer.write(code);
+  if(this._model !== 'qsprinter'){
+    this.buffer.write(_.CODE2D_FORMAT.TYPE_QR);
+    this.buffer.write(_.CODE2D_FORMAT.CODE2D);
+    this.buffer.writeUInt8(version || 3);
+    this.buffer.write(_.CODE2D_FORMAT[
+      'QR_LEVEL_' + (level || 'L').toUpperCase()
+    ]);
+    this.buffer.writeUInt8(size || 6);
+    this.buffer.writeUInt16LE(code.length);
+    this.buffer.write(code);
+  }else{
+    const dataRaw = iconv.encode(code, 'utf8');
+    if(dataRaw.length < 1 && dataRaw.length > 2710){
+      throw new Error('Invalid code length in byte. Must be between 1 and 2710');
+    }
+    // Barcode mode on
+    this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.ON);
+    
+    // Set pixel size
+    if(!size || (size && typeof size !== 'number'))
+      size = _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.DEFAULT;
+    else if(size && size < _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.MIN)
+      size = _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.MIN;
+    else if(size && size > _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.MAX)
+      size = _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.MAX;
+    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.CMD);
+    this.buffer.writeUInt8(size);
+    
+    // Set version
+    if(!version || (version && typeof version !== 'number'))
+      version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.DEFAULT;
+    else if(size && size < _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MIN)
+      version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MIN;
+    else if(size && size > _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MAX)
+      version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MAX;
+    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.CMD);
+    this.buffer.writeUInt8(version);
+    
+    // Set level
+    if(!level || (level && typeof level !== 'string'))
+      level = _.CODE2D_FORMAT.QR_LEVEL_L;
+    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.LEVEL.CMD);
+    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.LEVEL.OPTIONS[level.toUpperCase()]);
+  
+    // Transfer data(code) to buffer
+    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.SAVEBUF.CMD_P1);
+    this.buffer.writeUInt16LE(dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET);
+    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.SAVEBUF.CMD_P2);
+    this.buffer.write(dataRaw);
+  
+    // Print from buffer
+    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.PRINTBUF.CMD_P1);
+    this.buffer.writeUInt16LE(dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET);
+    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.PRINTBUF.CMD_P2);
+  
+    // Barcode mode off
+    this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.OFF);
+  }
   return this;
 };
 

--- a/printer.js
+++ b/printer.js
@@ -389,9 +389,6 @@ Printer.prototype.qrcode = function(code, version, level, size){
     if(dataRaw.length < 1 && dataRaw.length > 2710){
       throw new Error('Invalid code length in byte. Must be between 1 and 2710');
     }
-    // Barcode mode on
-    this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.ON);
-    
     // Set pixel size
     if(!size || (size && typeof size !== 'number'))
       size = _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.DEFAULT;
@@ -428,9 +425,6 @@ Printer.prototype.qrcode = function(code, version, level, size){
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.PRINTBUF.CMD_P1);
     this.buffer.writeUInt16LE(dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET);
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.PRINTBUF.CMD_P2);
-  
-    // Barcode mode off
-    this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.OFF);
   }
   return this;
 };


### PR DESCRIPTION
Hi,

I have added support for Qsprinter, particularly in printing barcode and QR code. It needs special commands to be able to print those.

Also, BARCODE_HEIGHT_DEFAULT the command should be \x1d**\x68**\x64. No worries, I fixed it.

Cheers!