### PR TITLE
Bugfix: Remove the detach listener once the device is closed, fix #35

### DIFF
--- a/adapter/usb.js
+++ b/adapter/usb.js
@@ -146,6 +146,7 @@ USB.prototype.close = function(callback){
   if(this.device) {
     this.emit('close', this.device);
     this.device.close();
+    usb.removeAllListeners('detach');
   }
   callback && callback();
   return this;


### PR DESCRIPTION
Fix #35 

## Reproducing bug: 
test.js
```
var escpos = require('escpos')
var device = escpos.USB();
device.close()
```
```
node test.js
```

This hangs on the terminal, needs to be terminated
