### PR TITLE
Make parity bit optional when printing barcode of EAN13/EAN8 and allow encoding to be set when constructing the printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ const device  = new escpos.USB();
 // const device  = new escpos.Network('localhost');
 // const device  = new escpos.Serial('/dev/usb/lp0');
 
-const printer = new escpos.Printer(device);
+const options = { encoding: "GB18030" /* default */ }
+// encoding is optional
+
+const printer = new escpos.Printer(device, options });
+
+
 
 device.open(function(){
   printer
@@ -177,12 +182,14 @@ width is a numeric value, 1 is for regular size, and 2 is twice the standard siz
 
 height is a numeric value, 1 is for regular size and 2 is twice the standard size. Default: 1
 
-#### barcode("code", "barcodeType", width, height, "position", "font")
+
+
+#### barcode("code", "barcodeType", "options")
 
 Prints a barcode.
 
-code is an alphanumeric code to be printed as bar code
-barcode_type must be one of the following type of codes:
+"code" is an alphanumeric code to be printed as bar code
+"barcodeType" must be one of the following type of codes:
 
 + UPC-A
 + UPC-E
@@ -193,10 +200,17 @@ barcode_type must be one of the following type of codes:
 + NW7
 
 The EAN type automatically calculates the last parity bit. For the EAN13 type, the length of the string is limited to 12, and EAN8 is limited to 7. (#57)
+If you wish to disable the parity bit you must set `"includeParity": false` in the options provided to the command.
 
-width is a numeric value in the range between (1,255) Default: 64
-height is a numeric value in the range between (2,6) Default: 3
-position is where to place the code around the bars, could be one of the following values:
+**"options"**
+
+"options.width" is a numeric value in the range between (1,255) Default: 64
+
+"options.height" is a numeric value in the range between (2,6) Default: 3
+
+"options.includeParity" is a boolean that defined if the parityBit shall be calculated to EAN13/EAN8 printers. default: true
+
+"options.position" is where to place the code around the bars, could be one of the following values:
 
 + ABOVE
 + BELOW
@@ -213,6 +227,15 @@ font is one of the 2 type of fonts, values could be:
 Default: A
 
 Raises BarcodeTypeError, BarcodeSizeError, BarcodeCodeError exceptions.
+
+For backward compatibility the old method interface is still supported:
+
+ ```
+  barcode("code", "barcodeType", width, height, "position", "font")
+  ```
+
+
+
 
 #### cut("mode")
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escpos",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "ESC/POS Printer driver for nodejs",
   "main": "index.js",
   "scripts": {

--- a/printer.js
+++ b/printer.js
@@ -302,22 +302,35 @@ Printer.prototype.hardware = function(hw){
  * [barcode]
  * @param  {[type]}    code     [description]
  * @param  {[type]}    type     [description]
- * @param  {[type]}    width    [description]
- * @param  {[type]}    height   [description]
- * @param  {[type]}    position [description]
- * @param  {[type]}    font     [description]
+ * @param options
  * @return printer instance
  */
-Printer.prototype.barcode = function(code, type, width, height, position, font){
+Printer.prototype.barcode = function(code, type, options){
+  options = options || {};
+  var width, height, position, font, includeParity;
+
+  if (typeof width === 'string' || typeof width === 'number'){ // That's because we are not using the options.object
+    width = arguments[2];
+    height = arguments[3];
+    position = arguments[4];
+    font = arguments[5];
+  } else {
+    width = options.width;
+    height = options.height;
+    position = options.position;
+    font = options.font;
+    includeParity = options.includeParity !== false; // true by default
+  }
+
   type = type || 'EAN13'; // default type is EAN13, may a good choice ?
   var convertCode = String(code), parityBit = '', codeLength = '';
   if(typeof type === 'undefined' || type === null){
     throw new TypeError('barcode type is required');
   }
-  if (type === 'EAN13' && convertCode.length != 12) {
+  if (type === 'EAN13' && convertCode.length !== 12) {
     throw new Error('EAN13 Barcode type requires code length 12');
   }
-  if (type === 'EAN8' && convertCode.length != 7) {
+  if (type === 'EAN8' && convertCode.length !== 7) {
     throw new Error('EAN8 Barcode type requires code length 7');
   }
   if(this._model === 'qsprinter'){
@@ -358,7 +371,7 @@ Printer.prototype.barcode = function(code, type, width, height, position, font){
   if(type == 'CODE128' || type == 'CODE93'){
     codeLength = utils.codeLength(code);
   }
-  this.buffer.write(codeLength + code + parityBit + '\x00');
+  this.buffer.write(codeLength + code + (  includeParity ?  parityBit : '' ) + '\x00'); // Allow to skip the parity byte
   if(this._model === 'qsprinter'){
     this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.OFF);
   }

--- a/printer.js
+++ b/printer.js
@@ -15,7 +15,7 @@ const Promiseify   = require('./promiseify');
  * @param  {[Adapter]} adapter [eg: usb, network, or serialport]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-function Printer(adapter){
+function Printer(adapter,options){
   if (!(this instanceof Printer)) {
     return new Printer(adapter);
   }
@@ -23,7 +23,7 @@ function Printer(adapter){
   EventEmitter.call(this);
   this.adapter = adapter;
   this.buffer = new Buffer();
-  this.encoding = 'GB18030';
+  this.encoding = options && options.encoding || 'GB18030';
   this._model = null;
 };
 


### PR DESCRIPTION
This pull request includes a few updates to the lib that will allow us control de parity bit.

