### PR TITLE
tests: use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 
 before_install:
   - sudo apt-get install build-essential libudev-dev -y
-
+  - npm i -g npm@latest
 
 install:
-  - npm install -g node-pre-gyp-github && npm i
+  - npm install -g node-pre-gyp-github && npm ci


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable