### PR TITLE
Coloring issue

### DIFF
--- a/image.js
+++ b/image.js
@@ -6,7 +6,7 @@ const getPixels = require('get-pixels');
  * @param {[type]} pixels [description]
  */
 function Image(pixels){
-  if(!(this instanceof Image))
+  if(!(this instanceof Image)) 
     return new Image(pixels);
   this.pixels = pixels;
 
@@ -31,7 +31,7 @@ function Image(pixels){
    if (pixel.a == 0) return 0;
    var shouldBeWhite = pixel.r > 200 && pixel.g > 200 && pixel.b > 200;
    return shouldBeWhite ? 0 : 1;
- });
+  });
 
 };
 

--- a/image.js
+++ b/image.js
@@ -1,13 +1,12 @@
-'use strict';
-const getPixels = require('get-pixels');
+"use strict";
+const getPixels = require("get-pixels");
 
 /**
  * [Image description]
  * @param {[type]} pixels [description]
  */
-function Image(pixels){
-  if(!(this instanceof Image)) 
-    return new Image(pixels);
+function Image(pixels) {
+  if (!(this instanceof Image)) return new Image(pixels);
   this.pixels = pixels;
 
   this.data = [];
@@ -18,21 +17,25 @@ function Image(pixels){
       b: pixel[2],
       a: pixel[3]
     };
-  };
+  }
 
   var self = this;
-  for(var i=0;i<this.pixels.data.length;i+=this.size.colors){
-    this.data.push(rgb(new Array(this.size.colors).fill(0).map(function(_, b){
-      return self.pixels.data[ i + b ];
-    })));
-  };
+  for (var i = 0; i < this.pixels.data.length; i += this.size.colors) {
+    this.data.push(
+      rgb(
+        new Array(this.size.colors).fill(0).map(function(_, b) {
+          return self.pixels.data[i + b];
+        })
+      )
+    );
+  }
 
-  this.data = this.data.map(function(pixel){
-    if(pixel.a == 0) return 0;
-    return pixel.r !== 0xFF || pixel.g !== 0xFF || pixel.b !== 0xFF ? 1 : 0;
+  this.data = this.data.map(function(pixel) {
+    if (pixel.a == 0) return 0;
+    var shouldBeWhite = pixel.r > 200 && pixel.g > 200 && pixel.b > 200;
+    return shouldBeWhite ? 0 : 1;
   });
-
-};
+}
 
 /**
  * [load description]
@@ -41,13 +44,13 @@ function Image(pixels){
  * @param  {Function} callback [description]
  * @return {[type]}            [description]
  */
-Image.load = function(url, type, callback){
-  if(typeof type == 'function'){
+Image.load = function(url, type, callback) {
+  if (typeof type == "function") {
     callback = type;
     type = null;
   }
-  getPixels(url, type, function(err, pixels){
-    if(err) return callback(err);
+  getPixels(url, type, function(err, pixels) {
+    if (err) return callback(err);
     callback(new Image(pixels));
   });
 };
@@ -56,11 +59,11 @@ Image.load = function(url, type, callback){
  * [description]
  * @return {[type]}     [description]
  */
-Image.prototype.__defineGetter__('size', function(){
+Image.prototype.__defineGetter__("size", function() {
   return {
-    width : this.pixels.shape[0],
+    width: this.pixels.shape[0],
     height: this.pixels.shape[1],
-    colors: this.pixels.shape[2],
+    colors: this.pixels.shape[2]
   };
 });
 
@@ -72,7 +75,8 @@ Image.prototype.__defineGetter__('size', function(){
 Image.prototype.toBitmap = function(density) {
   density = density || 24;
 
-  var ld, result = [];
+  var ld,
+    result = [];
   var x, y, b, l, i;
   var c = density / 8;
 
@@ -84,7 +88,6 @@ Image.prototype.toBitmap = function(density) {
     ld = result[y] = [];
 
     for (x = 0; x < this.size.width; x++) {
-
       for (b = 0; b < density; b++) {
         i = x * c + (b >> 3);
 
@@ -95,7 +98,7 @@ Image.prototype.toBitmap = function(density) {
         l = y * density + b;
         if (l < this.size.height) {
           if (this.data[l * this.size.width + x]) {
-            ld[i] += (0x80 >> (b & 0x7));
+            ld[i] += 0x80 >> (b & 0x7);
           }
         }
       }
@@ -111,20 +114,18 @@ Image.prototype.toBitmap = function(density) {
  * [toRaster description]
  * @return {[type]} [description]
  */
-Image.prototype.toRaster = function () {
+Image.prototype.toRaster = function() {
   var result = [];
-  var width  = this.size.width;
+  var width = this.size.width;
   var height = this.size.height;
-  var data   = this.data;
+  var data = this.data;
 
   // n blocks of lines
   var n = Math.ceil(width / 8);
   var x, y, b, c, i;
 
   for (y = 0; y < height; y++) {
-
     for (x = 0; x < n; x++) {
-
       for (b = 0; b < 8; b++) {
         i = x * 8 + b;
 
@@ -135,7 +136,7 @@ Image.prototype.toRaster = function () {
         c = x * 8 + b;
         if (c < width) {
           if (data[y * width + i]) {
-            result[y * n + x] += (0x80 >> (b & 0x7));
+            result[y * n + x] += 0x80 >> (b & 0x7);
           }
         }
       }
@@ -146,7 +147,7 @@ Image.prototype.toRaster = function () {
     width: n,
     height: height
   };
-}
+};
 
 /**
  * [exports description]

--- a/image.js
+++ b/image.js
@@ -1,12 +1,13 @@
-"use strict";
-const getPixels = require("get-pixels");
+'use strict';
+const getPixels = require('get-pixels');
 
 /**
  * [Image description]
  * @param {[type]} pixels [description]
  */
-function Image(pixels) {
-  if (!(this instanceof Image)) return new Image(pixels);
+function Image(pixels){
+  if(!(this instanceof Image))
+    return new Image(pixels);
   this.pixels = pixels;
 
   this.data = [];
@@ -17,25 +18,22 @@ function Image(pixels) {
       b: pixel[2],
       a: pixel[3]
     };
-  }
+  };
 
   var self = this;
-  for (var i = 0; i < this.pixels.data.length; i += this.size.colors) {
-    this.data.push(
-      rgb(
-        new Array(this.size.colors).fill(0).map(function(_, b) {
-          return self.pixels.data[i + b];
-        })
-      )
-    );
-  }
+  for(var i=0;i<this.pixels.data.length;i+=this.size.colors){
+    this.data.push(rgb(new Array(this.size.colors).fill(0).map(function(_, b){
+      return self.pixels.data[ i + b ];
+    })));
+  };
 
   this.data = this.data.map(function(pixel) {
-    if (pixel.a == 0) return 0;
-    var shouldBeWhite = pixel.r > 200 && pixel.g > 200 && pixel.b > 200;
-    return shouldBeWhite ? 0 : 1;
-  });
-}
+   if (pixel.a == 0) return 0;
+   var shouldBeWhite = pixel.r > 200 && pixel.g > 200 && pixel.b > 200;
+   return shouldBeWhite ? 0 : 1;
+ });
+
+};
 
 /**
  * [load description]
@@ -44,13 +42,13 @@ function Image(pixels) {
  * @param  {Function} callback [description]
  * @return {[type]}            [description]
  */
-Image.load = function(url, type, callback) {
-  if (typeof type == "function") {
+Image.load = function(url, type, callback){
+  if(typeof type == 'function'){
     callback = type;
     type = null;
   }
-  getPixels(url, type, function(err, pixels) {
-    if (err) return callback(err);
+  getPixels(url, type, function(err, pixels){
+    if(err) return callback(err);
     callback(new Image(pixels));
   });
 };
@@ -59,11 +57,11 @@ Image.load = function(url, type, callback) {
  * [description]
  * @return {[type]}     [description]
  */
-Image.prototype.__defineGetter__("size", function() {
+Image.prototype.__defineGetter__('size', function(){
   return {
-    width: this.pixels.shape[0],
+    width : this.pixels.shape[0],
     height: this.pixels.shape[1],
-    colors: this.pixels.shape[2]
+    colors: this.pixels.shape[2],
   };
 });
 
@@ -75,8 +73,7 @@ Image.prototype.__defineGetter__("size", function() {
 Image.prototype.toBitmap = function(density) {
   density = density || 24;
 
-  var ld,
-    result = [];
+  var ld, result = [];
   var x, y, b, l, i;
   var c = density / 8;
 
@@ -88,6 +85,7 @@ Image.prototype.toBitmap = function(density) {
     ld = result[y] = [];
 
     for (x = 0; x < this.size.width; x++) {
+
       for (b = 0; b < density; b++) {
         i = x * c + (b >> 3);
 
@@ -98,7 +96,7 @@ Image.prototype.toBitmap = function(density) {
         l = y * density + b;
         if (l < this.size.height) {
           if (this.data[l * this.size.width + x]) {
-            ld[i] += 0x80 >> (b & 0x7);
+            ld[i] += (0x80 >> (b & 0x7));
           }
         }
       }
@@ -114,18 +112,20 @@ Image.prototype.toBitmap = function(density) {
  * [toRaster description]
  * @return {[type]} [description]
  */
-Image.prototype.toRaster = function() {
+Image.prototype.toRaster = function () {
   var result = [];
-  var width = this.size.width;
+  var width  = this.size.width;
   var height = this.size.height;
-  var data = this.data;
+  var data   = this.data;
 
   // n blocks of lines
   var n = Math.ceil(width / 8);
   var x, y, b, c, i;
 
   for (y = 0; y < height; y++) {
+
     for (x = 0; x < n; x++) {
+
       for (b = 0; b < 8; b++) {
         i = x * 8 + b;
 
@@ -136,7 +136,7 @@ Image.prototype.toRaster = function() {
         c = x * 8 + b;
         if (c < width) {
           if (data[y * width + i]) {
-            result[y * n + x] += 0x80 >> (b & 0x7);
+            result[y * n + x] += (0x80 >> (b & 0x7));
           }
         }
       }
@@ -147,7 +147,7 @@ Image.prototype.toRaster = function() {
     width: n,
     height: height
   };
-};
+}
 
 /**
  * [exports description]

--- a/printer.js
+++ b/printer.js
@@ -499,7 +499,7 @@ Printer.prototype.image = function (image, density) {
 
   // added a delay so the printer can process the graphical data
   // when connected via slower connection ( e.g.: Serial)
-  bitmap.data.forEach(async (line) => {
+  for (var line of bitmap.data) {
     self.buffer.write(header);
     self.buffer.writeUInt16LE(line.length / n);
     self.buffer.write(line);
@@ -507,7 +507,7 @@ Printer.prototype.image = function (image, density) {
     await new Promise((resolve, reject) => {
       setTimeout(() => { resolve(true) }, 200);
     });
-  });
+  }
 
   return this;
 };

--- a/printer.js
+++ b/printer.js
@@ -602,7 +602,7 @@ Printer.prototype.close = function (callback, options) {
  */
 Printer.prototype.color = function (color) {
   this.buffer.write(_.COLOR[
-    color === 0 || color === 1 ? color: 0
+    color === 0 || color === 1 ? color : 0
   ]);
   return this;
 };

--- a/printer.js
+++ b/printer.js
@@ -499,7 +499,8 @@ Printer.prototype.image = function (image, density) {
 
   // added a delay so the printer can process the graphical data
   // when connected via slower connection ( e.g.: Serial)
-  bitmap.data.forEach(async (line) => {
+
+  for (var line of bitmap) {
     self.buffer.write(header);
     self.buffer.writeUInt16LE(line.length / n);
     self.buffer.write(line);
@@ -507,7 +508,7 @@ Printer.prototype.image = function (image, density) {
     await new Promise((resolve, reject) => {
       setTimeout(() => { resolve(true) }, 200);
     });
-  });
+  }
 
   return this;
 };

--- a/printer.js
+++ b/printer.js
@@ -602,7 +602,7 @@ Printer.prototype.close = function (callback, options) {
  */
 Printer.prototype.color = function (color) {
   this.buffer.write(_.COLOR[
-    color === 0 || color === 1 ? color : 0
+    color === 0 || color === 1 ? color: 0
   ]);
   return this;
 };

--- a/printer.js
+++ b/printer.js
@@ -1,14 +1,14 @@
-"use strict";
-const util = require("util");
-const qr = require("qr-image");
-const iconv = require("iconv-lite");
-const getPixels = require("get-pixels");
-const { MutableBuffer } = require("mutable-buffer");
-const EventEmitter = require("events");
-const Image = require("./image");
-const utils = require("./utils");
-const _ = require("./commands");
-const Promiseify = require("./promiseify");
+'use strict';
+const util = require('util');
+const qr = require('qr-image');
+const iconv = require('iconv-lite');
+const getPixels = require('get-pixels');
+const { MutableBuffer } = require('mutable-buffer');
+const EventEmitter = require('events');
+const Image = require('./image');
+const utils = require('./utils');
+const _ = require('./commands');
+const Promiseify = require('./promiseify');
 
 /**
  * [function ESC/POS Printer]
@@ -23,13 +23,13 @@ function Printer(adapter, options) {
   EventEmitter.call(this);
   this.adapter = adapter;
   this.buffer = new MutableBuffer();
-  this.encoding = (options && options.encoding) || "GB18030";
+  this.encoding = options && options.encoding || 'GB18030';
   this._model = null;
-}
+};
 
-Printer.create = function(device) {
+Printer.create = function (device) {
   const printer = new Printer(device);
-  return Promise.resolve(Promiseify(printer));
+  return Promise.resolve(Promiseify(printer))
 };
 
 /**
@@ -47,7 +47,7 @@ util.inherits(Printer, EventEmitter);
  * @param  {[String]}  model [mandatory]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.model = function(_model) {
+Printer.prototype.model = function (_model) {
   this._model = _model;
   return this;
 };
@@ -57,7 +57,7 @@ Printer.prototype.model = function(_model) {
  * @param  {[String]} size
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.marginBottom = function(size) {
+Printer.prototype.marginBottom = function (size) {
   this.buffer.write(_.MARGINS.BOTTOM);
   this.buffer.writeUInt8(size);
   return this;
@@ -68,7 +68,7 @@ Printer.prototype.marginBottom = function(size) {
  * @param  {[String]} size
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.marginLeft = function(size) {
+Printer.prototype.marginLeft = function (size) {
   this.buffer.write(_.MARGINS.LEFT);
   this.buffer.writeUInt8(size);
   return this;
@@ -79,7 +79,7 @@ Printer.prototype.marginLeft = function(size) {
  * @param  {[String]} size
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.marginRight = function(size) {
+Printer.prototype.marginRight = function (size) {
   this.buffer.write(_.MARGINS.RIGHT);
   this.buffer.writeUInt8(size);
   return this;
@@ -90,7 +90,7 @@ Printer.prototype.marginRight = function(size) {
  * @param  {[String]}  content  [mandatory]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.print = function(content) {
+Printer.prototype.print = function (content) {
   this.buffer.write(content);
   return this;
 };
@@ -99,7 +99,7 @@ Printer.prototype.print = function(content) {
  * @param  {[String]}  content  [mandatory]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.println = function(content) {
+Printer.prototype.println = function (content) {
   return this.print(content + _.EOL);
 };
 
@@ -109,7 +109,7 @@ Printer.prototype.println = function(content) {
  * @param  {[String]}  encoding [optional]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.text = function(content, encoding) {
+Printer.prototype.text = function (content, encoding) {
   return this.print(iconv.encode(content + _.EOL, encoding || this.encoding));
 };
 
@@ -119,7 +119,7 @@ Printer.prototype.text = function(content, encoding) {
  * @param  {[String]}  encoding [optional]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.pureText = function(content, encoding) {
+Printer.prototype.pureText = function (content, encoding) {
   return this.print(iconv.encode(content, encoding || this.encoding));
 };
 
@@ -128,18 +128,18 @@ Printer.prototype.pureText = function(content, encoding) {
  * @param  {[String]}  encoding [mandatory]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.encode = function(encoding) {
+Printer.prototype.encode = function (encoding) {
   this.encoding = encoding;
   return this;
-};
+}
 
 /**
  * [line feed]
  * @param  {[type]}    lines   [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.feed = function(n) {
-  this.buffer.write(new Array(n || 1).fill(_.EOL).join(""));
+Printer.prototype.feed = function (n) {
+  this.buffer.write(new Array(n || 1).fill(_.EOL).join(''));
   return this;
 };
 
@@ -148,8 +148,10 @@ Printer.prototype.feed = function(n) {
  * @param  {[type]}    ctrl     [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.control = function(ctrl) {
-  this.buffer.write(_.FEED_CONTROL_SEQUENCES["CTL_" + ctrl.toUpperCase()]);
+Printer.prototype.control = function (ctrl) {
+  this.buffer.write(_.FEED_CONTROL_SEQUENCES[
+    'CTL_' + ctrl.toUpperCase()
+  ]);
   return this;
 };
 /**
@@ -157,8 +159,10 @@ Printer.prototype.control = function(ctrl) {
  * @param  {[type]}    align    [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.align = function(align) {
-  this.buffer.write(_.TEXT_FORMAT["TXT_ALIGN_" + align.toUpperCase()]);
+Printer.prototype.align = function (align) {
+  this.buffer.write(_.TEXT_FORMAT[
+    'TXT_ALIGN_' + align.toUpperCase()
+  ]);
   return this;
 };
 /**
@@ -166,8 +170,10 @@ Printer.prototype.align = function(align) {
  * @param  {[type]}    family  [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.font = function(family) {
-  this.buffer.write(_.TEXT_FORMAT["TXT_FONT_" + family.toUpperCase()]);
+Printer.prototype.font = function (family) {
+  this.buffer.write(_.TEXT_FORMAT[
+    'TXT_FONT_' + family.toUpperCase()
+  ]);
   return this;
 };
 /**
@@ -175,71 +181,73 @@ Printer.prototype.font = function(family) {
  * @param  {[type]}    type     [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.style = function(type) {
+Printer.prototype.style = function (type) {
   switch (type.toUpperCase()) {
-    case "B":
+
+    case 'B':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_OFF);
       break;
-    case "I":
+    case 'I':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_OFF);
       break;
-    case "U":
+    case 'U':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_ON);
       break;
-    case "U2":
+    case 'U2':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL2_ON);
       break;
 
-    case "BI":
+    case 'BI':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_OFF);
       break;
-    case "BIU":
+    case 'BIU':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_ON);
       break;
-    case "BIU2":
+    case 'BIU2':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL2_ON);
       break;
-    case "BU":
+    case 'BU':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_ON);
       break;
-    case "BU2":
+    case 'BU2':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL2_ON);
       break;
-    case "IU":
+    case 'IU':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_ON);
       break;
-    case "IU2":
+    case 'IU2':
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL2_ON);
       break;
 
-    case "NORMAL":
+    case 'NORMAL':
     default:
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_OFF);
       break;
+
   }
   return this;
 };
@@ -250,7 +258,7 @@ Printer.prototype.style = function(type) {
  * @param  {[String]}  height  [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.size = function(width, height) {
+Printer.prototype.size = function (width, height) {
   if (2 >= width && 2 >= height) {
     this.buffer.write(_.TEXT_FORMAT.TXT_NORMAL);
     if (2 == width && 2 == height) {
@@ -271,7 +279,7 @@ Printer.prototype.size = function(width, height) {
  * @param  {[type]}    n     [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.spacing = function(n) {
+Printer.prototype.spacing = function (n) {
   if (n === undefined || n === null) {
     this.buffer.write(_.CHARACTER_SPACING.CS_DEFAULT);
   } else {
@@ -279,14 +287,14 @@ Printer.prototype.spacing = function(n) {
     this.buffer.writeUInt8(n);
   }
   return this;
-};
+}
 
 /**
  * [set line spacing]
  * @param  {[type]} n [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.lineSpace = function(n) {
+Printer.prototype.lineSpace = function (n) {
   if (n === undefined || n === null) {
     this.buffer.write(_.LINE_SPACING.LS_DEFAULT);
   } else {
@@ -301,8 +309,8 @@ Printer.prototype.lineSpace = function(n) {
  * @param  {[type]}    hw       [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.hardware = function(hw) {
-  this.buffer.write(_.HARDWARE["HW_" + hw.toUpperCase()]);
+Printer.prototype.hardware = function (hw) {
+  this.buffer.write(_.HARDWARE['HW_' + hw.toUpperCase()]);
   return this;
 };
 /**
@@ -313,11 +321,10 @@ Printer.prototype.hardware = function(hw) {
  * @return {[Printer]} printer  [the escpos printer instance]
  */
 
-Printer.prototype.barcode = function(code, type, options) {
+Printer.prototype.barcode = function (code, type, options) {
   options = options || {};
   var width, height, position, font, includeParity;
-  if (typeof width === "string" || typeof width === "number") {
-    // That's because we are not using the options.object
+  if (typeof width === 'string' || typeof width === 'number') { // That's because we are not using the options.object
     width = arguments[2];
     height = arguments[3];
     position = arguments[4];
@@ -330,23 +337,21 @@ Printer.prototype.barcode = function(code, type, options) {
     includeParity = options.includeParity !== false; // true by default
   }
 
-  type = type || "EAN13"; // default type is EAN13, may a good choice ?
-  var convertCode = String(code),
-    parityBit = "",
-    codeLength = "";
-  if (typeof type === "undefined" || type === null) {
-    throw new TypeError("barcode type is required");
+  type = type || 'EAN13'; // default type is EAN13, may a good choice ?
+  var convertCode = String(code), parityBit = '', codeLength = '';
+  if (typeof type === 'undefined' || type === null) {
+    throw new TypeError('barcode type is required');
   }
-  if (type === "EAN13" && convertCode.length !== 12) {
-    throw new Error("EAN13 Barcode type requires code length 12");
+  if (type === 'EAN13' && convertCode.length !== 12) {
+    throw new Error('EAN13 Barcode type requires code length 12');
   }
-  if (type === "EAN8" && convertCode.length !== 7) {
-    throw new Error("EAN8 Barcode type requires code length 7");
+  if (type === 'EAN8' && convertCode.length !== 7) {
+    throw new Error('EAN8 Barcode type requires code length 7');
   }
-  if (this._model === "qsprinter") {
+  if (this._model === 'qsprinter') {
     this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.ON);
   }
-  if (this._model === "qsprinter") {
+  if (this._model === 'qsprinter') {
     // qsprinter has no BARCODE_WIDTH command (as of v7.5)
   } else if (width >= 2 || width <= 6) {
     this.buffer.write(_.BARCODE_FORMAT.BARCODE_WIDTH[width]);
@@ -356,37 +361,33 @@ Printer.prototype.barcode = function(code, type, options) {
   if (height >= 1 || height <= 255) {
     this.buffer.write(_.BARCODE_FORMAT.BARCODE_HEIGHT(height));
   } else {
-    if (this._model === "qsprinter") {
+    if (this._model === 'qsprinter') {
       this.buffer.write(_.MODEL.QSPRINTER.BARCODE_HEIGHT_DEFAULT);
     } else {
       this.buffer.write(_.BARCODE_FORMAT.BARCODE_HEIGHT_DEFAULT);
     }
   }
-  if (this._model === "qsprinter") {
+  if (this._model === 'qsprinter') {
     // Qsprinter has no barcode font
   } else {
-    this.buffer.write(
-      _.BARCODE_FORMAT["BARCODE_FONT_" + (font || "A").toUpperCase()]
-    );
+    this.buffer.write(_.BARCODE_FORMAT[
+      'BARCODE_FONT_' + (font || 'A').toUpperCase()
+    ]);
   }
-  this.buffer.write(
-    _.BARCODE_FORMAT["BARCODE_TXT_" + (position || "BLW").toUpperCase()]
-  );
-  this.buffer.write(
-    _.BARCODE_FORMAT[
-      "BARCODE_" + (type || "EAN13").replace("-", "_").toUpperCase()
-    ]
-  );
-  if (type === "EAN13" || type === "EAN8") {
+  this.buffer.write(_.BARCODE_FORMAT[
+    'BARCODE_TXT_' + (position || 'BLW').toUpperCase()
+  ]);
+  this.buffer.write(_.BARCODE_FORMAT[
+    'BARCODE_' + ((type || 'EAN13').replace('-', '_').toUpperCase())
+  ]);
+  if (type === 'EAN13' || type === 'EAN8') {
     parityBit = utils.getParityBit(code);
   }
-  if (type == "CODE128" || type == "CODE93") {
+  if (type == 'CODE128' || type == 'CODE93') {
     codeLength = utils.codeLength(code);
   }
-  this.buffer.write(
-    codeLength + code + (includeParity ? parityBit : "") + "\x00"
-  ); // Allow to skip the parity byte
-  if (this._model === "qsprinter") {
+  this.buffer.write(codeLength + code + (includeParity ? parityBit : '') + '\x00'); // Allow to skip the parity byte
+  if (this._model === 'qsprinter') {
     this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.OFF);
   }
   return this;
@@ -400,27 +401,25 @@ Printer.prototype.barcode = function(code, type, options) {
  * @param  {[type]} size    [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.qrcode = function(code, version, level, size) {
-  if (this._model !== "qsprinter") {
+Printer.prototype.qrcode = function (code, version, level, size) {
+  if (this._model !== 'qsprinter') {
     this.buffer.write(_.CODE2D_FORMAT.TYPE_QR);
     this.buffer.write(_.CODE2D_FORMAT.CODE2D);
     this.buffer.writeUInt8(version || 3);
-    this.buffer.write(
-      _.CODE2D_FORMAT["QR_LEVEL_" + (level || "L").toUpperCase()]
-    );
+    this.buffer.write(_.CODE2D_FORMAT[
+      'QR_LEVEL_' + (level || 'L').toUpperCase()
+    ]);
     this.buffer.writeUInt8(size || 6);
     this.buffer.writeUInt16LE(code.length);
     this.buffer.write(code);
   } else {
-    const dataRaw = iconv.encode(code, "utf8");
+    const dataRaw = iconv.encode(code, 'utf8');
     if (dataRaw.length < 1 && dataRaw.length > 2710) {
-      throw new Error(
-        "Invalid code length in byte. Must be between 1 and 2710"
-      );
+      throw new Error('Invalid code length in byte. Must be between 1 and 2710');
     }
 
     // Set pixel size
-    if (!size || (size && typeof size !== "number"))
+    if (!size || (size && typeof size !== 'number'))
       size = _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.DEFAULT;
     else if (size && size < _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.MIN)
       size = _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.MIN;
@@ -430,7 +429,7 @@ Printer.prototype.qrcode = function(code, version, level, size) {
     this.buffer.writeUInt8(size);
 
     // Set version
-    if (!version || (version && typeof version !== "number"))
+    if (!version || (version && typeof version !== 'number'))
       version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.DEFAULT;
     else if (version && version < _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MIN)
       version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MIN;
@@ -440,26 +439,20 @@ Printer.prototype.qrcode = function(code, version, level, size) {
     this.buffer.writeUInt8(version);
 
     // Set level
-    if (!level || (level && typeof level !== "string"))
+    if (!level || (level && typeof level !== 'string'))
       level = _.CODE2D_FORMAT.QR_LEVEL_L;
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.LEVEL.CMD);
-    this.buffer.write(
-      _.MODEL.QSPRINTER.CODE2D_FORMAT.LEVEL.OPTIONS[level.toUpperCase()]
-    );
+    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.LEVEL.OPTIONS[level.toUpperCase()]);
 
     // Transfer data(code) to buffer
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.SAVEBUF.CMD_P1);
-    this.buffer.writeUInt16LE(
-      dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET
-    );
+    this.buffer.writeUInt16LE(dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET);
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.SAVEBUF.CMD_P2);
     this.buffer.write(dataRaw);
 
     // Print from buffer
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.PRINTBUF.CMD_P1);
-    this.buffer.writeUInt16LE(
-      dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET
-    );
+    this.buffer.writeUInt16LE(dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET);
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.PRINTBUF.CMD_P2);
   }
   return this;
@@ -472,16 +465,16 @@ Printer.prototype.qrcode = function(code, version, level, size) {
  * @param  {[Function]} callback [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.qrimage = function(content, options, callback) {
+Printer.prototype.qrimage = function (content, options, callback) {
   var self = this;
-  if (typeof options == "function") {
+  if (typeof options == 'function') {
     callback = options;
     options = null;
   }
-  options = options || { type: "png", mode: "dhdw" };
+  options = options || { type: 'png', mode: 'dhdw' };
   var buffer = qr.imageSync(content, options);
-  var type = ["image", options.type].join("/");
-  getPixels(buffer, type, function(err, pixels) {
+  var type = ['image', options.type].join('/');
+  getPixels(buffer, type, function (err, pixels) {
     if (err) return callback && callback(err);
     self.raster(new Image(pixels), options.mode);
     callback && callback.call(self, null, self);
@@ -495,26 +488,24 @@ Printer.prototype.qrimage = function(content, options, callback) {
  * @param  {[type]} density [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.image = function(image, density) {
+Printer.prototype.image = function (image, density) {
   if (!(image instanceof Image))
-    throw new TypeError("Only escpos.Image supported");
-  density = density || "d24";
-  var n = !!~["d8", "s8"].indexOf(density) ? 1 : 3;
-  var header = _.BITMAP_FORMAT["BITMAP_" + density.toUpperCase()];
+    throw new TypeError('Only escpos.Image supported');
+  density = density || 'd24';
+  var n = !!~['d8', 's8'].indexOf(density) ? 1 : 3;
+  var header = _.BITMAP_FORMAT['BITMAP_' + density.toUpperCase()];
   var bitmap = image.toBitmap(n * 8);
   var self = this;
 
   // added a delay so the printer can process the graphical data
   // when connected via slower connection ( e.g.: Serial)
-  bitmap.data.forEach(async line => {
+  bitmap.data.forEach(async (line) => {
     self.buffer.write(header);
     self.buffer.writeUInt16LE(line.length / n);
     self.buffer.write(line);
     self.buffer.write(_.ESC + _.FEED_CONTROL_SEQUENCES.CTL_GLF);
     await new Promise((resolve, reject) => {
-      setTimeout(() => {
-        resolve(true);
-      }, 200);
+      setTimeout(() => { resolve(true) }, 200);
     });
   });
 
@@ -527,13 +518,15 @@ Printer.prototype.image = function(image, density) {
  * @param  {[type]} mode  [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.raster = function(image, mode) {
+Printer.prototype.raster = function (image, mode) {
   if (!(image instanceof Image))
-    throw new TypeError("Only escpos.Image supported");
-  mode = mode || "normal";
-  if (mode === "dhdw" || mode === "dwh" || mode === "dhw") mode = "dwdh";
+    throw new TypeError('Only escpos.Image supported');
+  mode = mode || 'normal';
+  if (mode === 'dhdw' ||
+    mode === 'dwh' ||
+    mode === 'dhw') mode = 'dwdh';
   var raster = image.toRaster();
-  var header = _.GSV0_FORMAT["GSV0_" + mode.toUpperCase()];
+  var header = _.GSV0_FORMAT['GSV0_' + mode.toUpperCase()];
   this.buffer.write(header);
   this.buffer.writeUInt16LE(raster.width);
   this.buffer.writeUInt16LE(raster.height);
@@ -546,8 +539,10 @@ Printer.prototype.raster = function(image, mode) {
  * @param  {[type]} pin [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.cashdraw = function(pin) {
-  this.buffer.write(_.CASH_DRAWER["CD_KICK_" + (pin || 2)]);
+Printer.prototype.cashdraw = function (pin) {
+  this.buffer.write(_.CASH_DRAWER[
+    'CD_KICK_' + (pin || 2)
+  ]);
   return this;
 };
 
@@ -556,7 +551,7 @@ Printer.prototype.cashdraw = function(pin) {
  * @param  {[String]} n Refers to the number of buzzer times
  * @param  {[String]} t Refers to the buzzer sound length in (t * 100) milliseconds.
  */
-Printer.prototype.beep = function(n, t) {
+Printer.prototype.beep = function (n, t) {
   this.buffer.write(_.BEEP);
   this.buffer.writeUInt8(n);
   this.buffer.writeUInt8(t);
@@ -568,7 +563,7 @@ Printer.prototype.beep = function(n, t) {
  * @param  {Function} callback
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.flush = function(callback) {
+Printer.prototype.flush = function (callback) {
   var buf = this.buffer.flush();
   this.adapter.write(buf, callback);
   return this;
@@ -579,9 +574,11 @@ Printer.prototype.flush = function(callback) {
  * @param  {[type]} part [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.cut = function(part, feed) {
+Printer.prototype.cut = function (part, feed) {
   this.feed(feed || 3);
-  this.buffer.write(_.PAPER[part ? "PAPER_PART_CUT" : "PAPER_FULL_CUT"]);
+  this.buffer.write(_.PAPER[
+    part ? 'PAPER_PART_CUT' : 'PAPER_FULL_CUT'
+  ]);
   return this;
 };
 
@@ -591,9 +588,9 @@ Printer.prototype.cut = function(part, feed) {
  * @param  {[type]}   options  [description]
  * @return {[type]}            [description]
  */
-Printer.prototype.close = function(callback, options) {
+Printer.prototype.close = function (callback, options) {
   var self = this;
-  return this.flush(function() {
+  return this.flush(function () {
     self.adapter.close(callback, options);
   });
 };
@@ -603,8 +600,10 @@ Printer.prototype.close = function(callback, options) {
  * @param  {Number} color - 0 for primary color (black) 1 for secondary color (red)
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.color = function(color) {
-  this.buffer.write(_.COLOR[color === 0 || color === 1 ? color : 0]);
+Printer.prototype.color = function (color) {
+  this.buffer.write(_.COLOR[
+    color === 0 || color === 1 ? color: 0
+  ]);
   return this;
 };
 

--- a/printer.js
+++ b/printer.js
@@ -1,14 +1,14 @@
-'use strict';
-const util = require('util');
-const qr = require('qr-image');
-const iconv = require('iconv-lite');
-const getPixels = require('get-pixels');
-const { MutableBuffer } = require('mutable-buffer');
-const EventEmitter = require('events');
-const Image = require('./image');
-const utils = require('./utils');
-const _ = require('./commands');
-const Promiseify = require('./promiseify');
+"use strict";
+const util = require("util");
+const qr = require("qr-image");
+const iconv = require("iconv-lite");
+const getPixels = require("get-pixels");
+const { MutableBuffer } = require("mutable-buffer");
+const EventEmitter = require("events");
+const Image = require("./image");
+const utils = require("./utils");
+const _ = require("./commands");
+const Promiseify = require("./promiseify");
 
 /**
  * [function ESC/POS Printer]
@@ -23,13 +23,13 @@ function Printer(adapter, options) {
   EventEmitter.call(this);
   this.adapter = adapter;
   this.buffer = new MutableBuffer();
-  this.encoding = options && options.encoding || 'GB18030';
+  this.encoding = (options && options.encoding) || "GB18030";
   this._model = null;
-};
+}
 
-Printer.create = function (device) {
+Printer.create = function(device) {
   const printer = new Printer(device);
-  return Promise.resolve(Promiseify(printer))
+  return Promise.resolve(Promiseify(printer));
 };
 
 /**
@@ -47,7 +47,7 @@ util.inherits(Printer, EventEmitter);
  * @param  {[String]}  model [mandatory]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.model = function (_model) {
+Printer.prototype.model = function(_model) {
   this._model = _model;
   return this;
 };
@@ -57,7 +57,7 @@ Printer.prototype.model = function (_model) {
  * @param  {[String]} size
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.marginBottom = function (size) {
+Printer.prototype.marginBottom = function(size) {
   this.buffer.write(_.MARGINS.BOTTOM);
   this.buffer.writeUInt8(size);
   return this;
@@ -68,7 +68,7 @@ Printer.prototype.marginBottom = function (size) {
  * @param  {[String]} size
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.marginLeft = function (size) {
+Printer.prototype.marginLeft = function(size) {
   this.buffer.write(_.MARGINS.LEFT);
   this.buffer.writeUInt8(size);
   return this;
@@ -79,7 +79,7 @@ Printer.prototype.marginLeft = function (size) {
  * @param  {[String]} size
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.marginRight = function (size) {
+Printer.prototype.marginRight = function(size) {
   this.buffer.write(_.MARGINS.RIGHT);
   this.buffer.writeUInt8(size);
   return this;
@@ -90,7 +90,7 @@ Printer.prototype.marginRight = function (size) {
  * @param  {[String]}  content  [mandatory]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.print = function (content) {
+Printer.prototype.print = function(content) {
   this.buffer.write(content);
   return this;
 };
@@ -99,7 +99,7 @@ Printer.prototype.print = function (content) {
  * @param  {[String]}  content  [mandatory]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.println = function (content) {
+Printer.prototype.println = function(content) {
   return this.print(content + _.EOL);
 };
 
@@ -109,7 +109,7 @@ Printer.prototype.println = function (content) {
  * @param  {[String]}  encoding [optional]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.text = function (content, encoding) {
+Printer.prototype.text = function(content, encoding) {
   return this.print(iconv.encode(content + _.EOL, encoding || this.encoding));
 };
 
@@ -119,7 +119,7 @@ Printer.prototype.text = function (content, encoding) {
  * @param  {[String]}  encoding [optional]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.pureText = function (content, encoding) {
+Printer.prototype.pureText = function(content, encoding) {
   return this.print(iconv.encode(content, encoding || this.encoding));
 };
 
@@ -128,18 +128,18 @@ Printer.prototype.pureText = function (content, encoding) {
  * @param  {[String]}  encoding [mandatory]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.encode = function (encoding) {
+Printer.prototype.encode = function(encoding) {
   this.encoding = encoding;
   return this;
-}
+};
 
 /**
  * [line feed]
  * @param  {[type]}    lines   [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.feed = function (n) {
-  this.buffer.write(new Array(n || 1).fill(_.EOL).join(''));
+Printer.prototype.feed = function(n) {
+  this.buffer.write(new Array(n || 1).fill(_.EOL).join(""));
   return this;
 };
 
@@ -148,10 +148,8 @@ Printer.prototype.feed = function (n) {
  * @param  {[type]}    ctrl     [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.control = function (ctrl) {
-  this.buffer.write(_.FEED_CONTROL_SEQUENCES[
-    'CTL_' + ctrl.toUpperCase()
-  ]);
+Printer.prototype.control = function(ctrl) {
+  this.buffer.write(_.FEED_CONTROL_SEQUENCES["CTL_" + ctrl.toUpperCase()]);
   return this;
 };
 /**
@@ -159,10 +157,8 @@ Printer.prototype.control = function (ctrl) {
  * @param  {[type]}    align    [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.align = function (align) {
-  this.buffer.write(_.TEXT_FORMAT[
-    'TXT_ALIGN_' + align.toUpperCase()
-  ]);
+Printer.prototype.align = function(align) {
+  this.buffer.write(_.TEXT_FORMAT["TXT_ALIGN_" + align.toUpperCase()]);
   return this;
 };
 /**
@@ -170,10 +166,8 @@ Printer.prototype.align = function (align) {
  * @param  {[type]}    family  [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.font = function (family) {
-  this.buffer.write(_.TEXT_FORMAT[
-    'TXT_FONT_' + family.toUpperCase()
-  ]);
+Printer.prototype.font = function(family) {
+  this.buffer.write(_.TEXT_FORMAT["TXT_FONT_" + family.toUpperCase()]);
   return this;
 };
 /**
@@ -181,73 +175,71 @@ Printer.prototype.font = function (family) {
  * @param  {[type]}    type     [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.style = function (type) {
+Printer.prototype.style = function(type) {
   switch (type.toUpperCase()) {
-
-    case 'B':
+    case "B":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_OFF);
       break;
-    case 'I':
+    case "I":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_OFF);
       break;
-    case 'U':
+    case "U":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_ON);
       break;
-    case 'U2':
+    case "U2":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL2_ON);
       break;
 
-    case 'BI':
+    case "BI":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_OFF);
       break;
-    case 'BIU':
+    case "BIU":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_ON);
       break;
-    case 'BIU2':
+    case "BIU2":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL2_ON);
       break;
-    case 'BU':
+    case "BU":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_ON);
       break;
-    case 'BU2':
+    case "BU2":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL2_ON);
       break;
-    case 'IU':
+    case "IU":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_ON);
       break;
-    case 'IU2':
+    case "IU2":
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_ON);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL2_ON);
       break;
 
-    case 'NORMAL':
+    case "NORMAL":
     default:
       this.buffer.write(_.TEXT_FORMAT.TXT_BOLD_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_ITALIC_OFF);
       this.buffer.write(_.TEXT_FORMAT.TXT_UNDERL_OFF);
       break;
-
   }
   return this;
 };
@@ -258,7 +250,7 @@ Printer.prototype.style = function (type) {
  * @param  {[String]}  height  [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.size = function (width, height) {
+Printer.prototype.size = function(width, height) {
   if (2 >= width && 2 >= height) {
     this.buffer.write(_.TEXT_FORMAT.TXT_NORMAL);
     if (2 == width && 2 == height) {
@@ -279,7 +271,7 @@ Printer.prototype.size = function (width, height) {
  * @param  {[type]}    n     [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.spacing = function (n) {
+Printer.prototype.spacing = function(n) {
   if (n === undefined || n === null) {
     this.buffer.write(_.CHARACTER_SPACING.CS_DEFAULT);
   } else {
@@ -287,14 +279,14 @@ Printer.prototype.spacing = function (n) {
     this.buffer.writeUInt8(n);
   }
   return this;
-}
+};
 
 /**
  * [set line spacing]
  * @param  {[type]} n [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.lineSpace = function (n) {
+Printer.prototype.lineSpace = function(n) {
   if (n === undefined || n === null) {
     this.buffer.write(_.LINE_SPACING.LS_DEFAULT);
   } else {
@@ -309,8 +301,8 @@ Printer.prototype.lineSpace = function (n) {
  * @param  {[type]}    hw       [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.hardware = function (hw) {
-  this.buffer.write(_.HARDWARE['HW_' + hw.toUpperCase()]);
+Printer.prototype.hardware = function(hw) {
+  this.buffer.write(_.HARDWARE["HW_" + hw.toUpperCase()]);
   return this;
 };
 /**
@@ -321,10 +313,11 @@ Printer.prototype.hardware = function (hw) {
  * @return {[Printer]} printer  [the escpos printer instance]
  */
 
-Printer.prototype.barcode = function (code, type, options) {
+Printer.prototype.barcode = function(code, type, options) {
   options = options || {};
   var width, height, position, font, includeParity;
-  if (typeof width === 'string' || typeof width === 'number') { // That's because we are not using the options.object
+  if (typeof width === "string" || typeof width === "number") {
+    // That's because we are not using the options.object
     width = arguments[2];
     height = arguments[3];
     position = arguments[4];
@@ -337,21 +330,23 @@ Printer.prototype.barcode = function (code, type, options) {
     includeParity = options.includeParity !== false; // true by default
   }
 
-  type = type || 'EAN13'; // default type is EAN13, may a good choice ?
-  var convertCode = String(code), parityBit = '', codeLength = '';
-  if (typeof type === 'undefined' || type === null) {
-    throw new TypeError('barcode type is required');
+  type = type || "EAN13"; // default type is EAN13, may a good choice ?
+  var convertCode = String(code),
+    parityBit = "",
+    codeLength = "";
+  if (typeof type === "undefined" || type === null) {
+    throw new TypeError("barcode type is required");
   }
-  if (type === 'EAN13' && convertCode.length !== 12) {
-    throw new Error('EAN13 Barcode type requires code length 12');
+  if (type === "EAN13" && convertCode.length !== 12) {
+    throw new Error("EAN13 Barcode type requires code length 12");
   }
-  if (type === 'EAN8' && convertCode.length !== 7) {
-    throw new Error('EAN8 Barcode type requires code length 7');
+  if (type === "EAN8" && convertCode.length !== 7) {
+    throw new Error("EAN8 Barcode type requires code length 7");
   }
-  if (this._model === 'qsprinter') {
+  if (this._model === "qsprinter") {
     this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.ON);
   }
-  if (this._model === 'qsprinter') {
+  if (this._model === "qsprinter") {
     // qsprinter has no BARCODE_WIDTH command (as of v7.5)
   } else if (width >= 2 || width <= 6) {
     this.buffer.write(_.BARCODE_FORMAT.BARCODE_WIDTH[width]);
@@ -361,33 +356,37 @@ Printer.prototype.barcode = function (code, type, options) {
   if (height >= 1 || height <= 255) {
     this.buffer.write(_.BARCODE_FORMAT.BARCODE_HEIGHT(height));
   } else {
-    if (this._model === 'qsprinter') {
+    if (this._model === "qsprinter") {
       this.buffer.write(_.MODEL.QSPRINTER.BARCODE_HEIGHT_DEFAULT);
     } else {
       this.buffer.write(_.BARCODE_FORMAT.BARCODE_HEIGHT_DEFAULT);
     }
   }
-  if (this._model === 'qsprinter') {
+  if (this._model === "qsprinter") {
     // Qsprinter has no barcode font
   } else {
-    this.buffer.write(_.BARCODE_FORMAT[
-      'BARCODE_FONT_' + (font || 'A').toUpperCase()
-    ]);
+    this.buffer.write(
+      _.BARCODE_FORMAT["BARCODE_FONT_" + (font || "A").toUpperCase()]
+    );
   }
-  this.buffer.write(_.BARCODE_FORMAT[
-    'BARCODE_TXT_' + (position || 'BLW').toUpperCase()
-  ]);
-  this.buffer.write(_.BARCODE_FORMAT[
-    'BARCODE_' + ((type || 'EAN13').replace('-', '_').toUpperCase())
-  ]);
-  if (type === 'EAN13' || type === 'EAN8') {
+  this.buffer.write(
+    _.BARCODE_FORMAT["BARCODE_TXT_" + (position || "BLW").toUpperCase()]
+  );
+  this.buffer.write(
+    _.BARCODE_FORMAT[
+      "BARCODE_" + (type || "EAN13").replace("-", "_").toUpperCase()
+    ]
+  );
+  if (type === "EAN13" || type === "EAN8") {
     parityBit = utils.getParityBit(code);
   }
-  if (type == 'CODE128' || type == 'CODE93') {
+  if (type == "CODE128" || type == "CODE93") {
     codeLength = utils.codeLength(code);
   }
-  this.buffer.write(codeLength + code + (includeParity ? parityBit : '') + '\x00'); // Allow to skip the parity byte
-  if (this._model === 'qsprinter') {
+  this.buffer.write(
+    codeLength + code + (includeParity ? parityBit : "") + "\x00"
+  ); // Allow to skip the parity byte
+  if (this._model === "qsprinter") {
     this.buffer.write(_.MODEL.QSPRINTER.BARCODE_MODE.OFF);
   }
   return this;
@@ -401,25 +400,27 @@ Printer.prototype.barcode = function (code, type, options) {
  * @param  {[type]} size    [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.qrcode = function (code, version, level, size) {
-  if (this._model !== 'qsprinter') {
+Printer.prototype.qrcode = function(code, version, level, size) {
+  if (this._model !== "qsprinter") {
     this.buffer.write(_.CODE2D_FORMAT.TYPE_QR);
     this.buffer.write(_.CODE2D_FORMAT.CODE2D);
     this.buffer.writeUInt8(version || 3);
-    this.buffer.write(_.CODE2D_FORMAT[
-      'QR_LEVEL_' + (level || 'L').toUpperCase()
-    ]);
+    this.buffer.write(
+      _.CODE2D_FORMAT["QR_LEVEL_" + (level || "L").toUpperCase()]
+    );
     this.buffer.writeUInt8(size || 6);
     this.buffer.writeUInt16LE(code.length);
     this.buffer.write(code);
   } else {
-    const dataRaw = iconv.encode(code, 'utf8');
+    const dataRaw = iconv.encode(code, "utf8");
     if (dataRaw.length < 1 && dataRaw.length > 2710) {
-      throw new Error('Invalid code length in byte. Must be between 1 and 2710');
+      throw new Error(
+        "Invalid code length in byte. Must be between 1 and 2710"
+      );
     }
 
     // Set pixel size
-    if (!size || (size && typeof size !== 'number'))
+    if (!size || (size && typeof size !== "number"))
       size = _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.DEFAULT;
     else if (size && size < _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.MIN)
       size = _.MODEL.QSPRINTER.CODE2D_FORMAT.PIXEL_SIZE.MIN;
@@ -429,7 +430,7 @@ Printer.prototype.qrcode = function (code, version, level, size) {
     this.buffer.writeUInt8(size);
 
     // Set version
-    if (!version || (version && typeof version !== 'number'))
+    if (!version || (version && typeof version !== "number"))
       version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.DEFAULT;
     else if (version && version < _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MIN)
       version = _.MODEL.QSPRINTER.CODE2D_FORMAT.VERSION.MIN;
@@ -439,20 +440,26 @@ Printer.prototype.qrcode = function (code, version, level, size) {
     this.buffer.writeUInt8(version);
 
     // Set level
-    if (!level || (level && typeof level !== 'string'))
+    if (!level || (level && typeof level !== "string"))
       level = _.CODE2D_FORMAT.QR_LEVEL_L;
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.LEVEL.CMD);
-    this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.LEVEL.OPTIONS[level.toUpperCase()]);
+    this.buffer.write(
+      _.MODEL.QSPRINTER.CODE2D_FORMAT.LEVEL.OPTIONS[level.toUpperCase()]
+    );
 
     // Transfer data(code) to buffer
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.SAVEBUF.CMD_P1);
-    this.buffer.writeUInt16LE(dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET);
+    this.buffer.writeUInt16LE(
+      dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET
+    );
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.SAVEBUF.CMD_P2);
     this.buffer.write(dataRaw);
 
     // Print from buffer
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.PRINTBUF.CMD_P1);
-    this.buffer.writeUInt16LE(dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET);
+    this.buffer.writeUInt16LE(
+      dataRaw.length + _.MODEL.QSPRINTER.CODE2D_FORMAT.LEN_OFFSET
+    );
     this.buffer.write(_.MODEL.QSPRINTER.CODE2D_FORMAT.PRINTBUF.CMD_P2);
   }
   return this;
@@ -465,16 +472,16 @@ Printer.prototype.qrcode = function (code, version, level, size) {
  * @param  {[Function]} callback [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.qrimage = function (content, options, callback) {
+Printer.prototype.qrimage = function(content, options, callback) {
   var self = this;
-  if (typeof options == 'function') {
+  if (typeof options == "function") {
     callback = options;
     options = null;
   }
-  options = options || { type: 'png', mode: 'dhdw' };
+  options = options || { type: "png", mode: "dhdw" };
   var buffer = qr.imageSync(content, options);
-  var type = ['image', options.type].join('/');
-  getPixels(buffer, type, function (err, pixels) {
+  var type = ["image", options.type].join("/");
+  getPixels(buffer, type, function(err, pixels) {
     if (err) return callback && callback(err);
     self.raster(new Image(pixels), options.mode);
     callback && callback.call(self, null, self);
@@ -488,27 +495,28 @@ Printer.prototype.qrimage = function (content, options, callback) {
  * @param  {[type]} density [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.image = function (image, density) {
+Printer.prototype.image = function(image, density) {
   if (!(image instanceof Image))
-    throw new TypeError('Only escpos.Image supported');
-  density = density || 'd24';
-  var n = !!~['d8', 's8'].indexOf(density) ? 1 : 3;
-  var header = _.BITMAP_FORMAT['BITMAP_' + density.toUpperCase()];
+    throw new TypeError("Only escpos.Image supported");
+  density = density || "d24";
+  var n = !!~["d8", "s8"].indexOf(density) ? 1 : 3;
+  var header = _.BITMAP_FORMAT["BITMAP_" + density.toUpperCase()];
   var bitmap = image.toBitmap(n * 8);
   var self = this;
 
   // added a delay so the printer can process the graphical data
   // when connected via slower connection ( e.g.: Serial)
-
-  for (var line of bitmap) {
+  bitmap.data.forEach(async line => {
     self.buffer.write(header);
     self.buffer.writeUInt16LE(line.length / n);
     self.buffer.write(line);
     self.buffer.write(_.ESC + _.FEED_CONTROL_SEQUENCES.CTL_GLF);
     await new Promise((resolve, reject) => {
-      setTimeout(() => { resolve(true) }, 200);
+      setTimeout(() => {
+        resolve(true);
+      }, 200);
     });
-  }
+  });
 
   return this;
 };
@@ -519,15 +527,13 @@ Printer.prototype.image = function (image, density) {
  * @param  {[type]} mode  [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.raster = function (image, mode) {
+Printer.prototype.raster = function(image, mode) {
   if (!(image instanceof Image))
-    throw new TypeError('Only escpos.Image supported');
-  mode = mode || 'normal';
-  if (mode === 'dhdw' ||
-    mode === 'dwh' ||
-    mode === 'dhw') mode = 'dwdh';
+    throw new TypeError("Only escpos.Image supported");
+  mode = mode || "normal";
+  if (mode === "dhdw" || mode === "dwh" || mode === "dhw") mode = "dwdh";
   var raster = image.toRaster();
-  var header = _.GSV0_FORMAT['GSV0_' + mode.toUpperCase()];
+  var header = _.GSV0_FORMAT["GSV0_" + mode.toUpperCase()];
   this.buffer.write(header);
   this.buffer.writeUInt16LE(raster.width);
   this.buffer.writeUInt16LE(raster.height);
@@ -540,10 +546,8 @@ Printer.prototype.raster = function (image, mode) {
  * @param  {[type]} pin [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.cashdraw = function (pin) {
-  this.buffer.write(_.CASH_DRAWER[
-    'CD_KICK_' + (pin || 2)
-  ]);
+Printer.prototype.cashdraw = function(pin) {
+  this.buffer.write(_.CASH_DRAWER["CD_KICK_" + (pin || 2)]);
   return this;
 };
 
@@ -552,7 +556,7 @@ Printer.prototype.cashdraw = function (pin) {
  * @param  {[String]} n Refers to the number of buzzer times
  * @param  {[String]} t Refers to the buzzer sound length in (t * 100) milliseconds.
  */
-Printer.prototype.beep = function (n, t) {
+Printer.prototype.beep = function(n, t) {
   this.buffer.write(_.BEEP);
   this.buffer.writeUInt8(n);
   this.buffer.writeUInt8(t);
@@ -564,7 +568,7 @@ Printer.prototype.beep = function (n, t) {
  * @param  {Function} callback
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.flush = function (callback) {
+Printer.prototype.flush = function(callback) {
   var buf = this.buffer.flush();
   this.adapter.write(buf, callback);
   return this;
@@ -575,11 +579,9 @@ Printer.prototype.flush = function (callback) {
  * @param  {[type]} part [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.cut = function (part, feed) {
+Printer.prototype.cut = function(part, feed) {
   this.feed(feed || 3);
-  this.buffer.write(_.PAPER[
-    part ? 'PAPER_PART_CUT' : 'PAPER_FULL_CUT'
-  ]);
+  this.buffer.write(_.PAPER[part ? "PAPER_PART_CUT" : "PAPER_FULL_CUT"]);
   return this;
 };
 
@@ -589,9 +591,9 @@ Printer.prototype.cut = function (part, feed) {
  * @param  {[type]}   options  [description]
  * @return {[type]}            [description]
  */
-Printer.prototype.close = function (callback, options) {
+Printer.prototype.close = function(callback, options) {
   var self = this;
-  return this.flush(function () {
+  return this.flush(function() {
     self.adapter.close(callback, options);
   });
 };
@@ -601,10 +603,8 @@ Printer.prototype.close = function (callback, options) {
  * @param  {Number} color - 0 for primary color (black) 1 for secondary color (red)
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.color = function (color) {
-  this.buffer.write(_.COLOR[
-    color === 0 || color === 1 ? color: 0
-  ]);
+Printer.prototype.color = function(color) {
+  this.buffer.write(_.COLOR[color === 0 || color === 1 ? color : 0]);
   return this;
 };
 


### PR DESCRIPTION
The problem is that you check if pixels are exactly white, then white, otherwise black. In some cases, where I would accept colored images, some "white"ish pixels would be not #fff maybe, but #fafafa. Close to white and should be white.

Maybe you were expecting only black and white images. So it resulted in images on receipts which would be black in places, where it didn't need to be.

I fixed it for myself and tested it with a bunch of colored images, it works. If you think this is helpful merge it to master. Thanks.