### PR TITLE
Fix coloring issue (!)

### DIFF
--- a/image.js
+++ b/image.js
@@ -27,9 +27,10 @@ function Image(pixels){
     })));
   };
 
-  this.data = this.data.map(function(pixel){
-    if(pixel.a == 0) return 0;
-    return pixel.r !== 0xFF || pixel.g !== 0xFF || pixel.b !== 0xFF ? 1 : 0;
+  this.data = this.data.map(function(pixel) {
+   if (pixel.a == 0) return 0;
+   var shouldBeWhite = pixel.r > 200 && pixel.g > 200 && pixel.b > 200;
+   return shouldBeWhite ? 0 : 1;
   });
 
 };


### PR DESCRIPTION
Not very good with git apparently, so I couldn't fix that PR, and just opened a new one. 
Fixes the problem I described in other PR:

> The problem is that you check if pixels are exactly white, then white, otherwise black. In some cases, where I would accept colored images, some "white"ish pixels would be not #fff maybe, but #fafafa. Close to white and should be white.
> 
> Maybe you were expecting only black and white images. So it resulted in images on receipts which would be black in places, where it didn't need to be.
> 
> I fixed it for myself and tested it with a bunch of colored images, it works. If you think this is helpful merge it to master. Thanks.