### PR TITLE
make function async

### DIFF
--- a/printer.js
+++ b/printer.js
@@ -488,7 +488,7 @@ Printer.prototype.qrimage = function (content, options, callback) {
  * @param  {[type]} density [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.image = function (image, density) {
+Printer.prototype.image = async function (image, density) {
   if (!(image instanceof Image))
     throw new TypeError('Only escpos.Image supported');
   density = density || 'd24';


### PR DESCRIPTION
As pointed out by @ozgursel for await to work the function should be async. Sorry for inattention, my mistake.


I no longer have access to the printers though, so if anybody of repo owners/collaborators have please test the latest code. Thanks. Should be ok now, though.