### PR TITLE
Modifications on printer image() function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,27 @@
+module.exports = {
+    "env": {
+        "node" : true,
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 2017
+    },
+    "rules": {
+        "indent": [
+            "error",
+            "space"
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+};

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Printer Buzzer (Beep sound).
 + [Sébastien Vidal](https://github.com/Psychopoulet)
 + [Yu Yongwoo](https://github.com/uyu423)
 + [Attawit Kittikrairit](https://github.com/atton16)
++ [Risley Lima](https://github.com/risleylima)
 
 ----
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escpos",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "ESC/POS Printer driver for nodejs",
   "main": "index.js",
   "scripts": {

--- a/printer.js
+++ b/printer.js
@@ -488,7 +488,7 @@ Printer.prototype.qrimage = function (content, options, callback) {
  * @param  {[type]} density [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.image = async function (image, density, use_glf) {
+Printer.prototype.image = function (image, density, use_glf) {
   if (!(image instanceof Image))
     throw new TypeError('Only escpos.Image supported');
   density = density || 'd24';

--- a/printer.js
+++ b/printer.js
@@ -488,7 +488,7 @@ Printer.prototype.qrimage = function (content, options, callback) {
  * @param  {[type]} density [description]
  * @return {[Printer]} printer  [the escpos printer instance]
  */
-Printer.prototype.image = async function (image, density) {
+Printer.prototype.image = async function (image, density, use_glf) {
   if (!(image instanceof Image))
     throw new TypeError('Only escpos.Image supported');
   density = density || 'd24';
@@ -499,17 +499,21 @@ Printer.prototype.image = async function (image, density) {
 
   // added a delay so the printer can process the graphical data
   // when connected via slower connection ( e.g.: Serial)
-  this.lineSpace(0); // set line spacing to 0
+  if(!use_glf){
+    this.lineSpace(0); // set line spacing to 0
+  }
+
   bitmap.data.forEach(async (line) => {
     self.buffer.write(header);
     self.buffer.writeUInt16LE(line.length / n);
     self.buffer.write(line);
-    self.buffer.write(_.EOL);
+    self.buffer.write(!use_glf ? _.EOL : _.ESC+_.FEED_CONTROL_SEQUENCES.CTL_GLF);
     await new Promise((resolve, reject) => {
       setTimeout(() => { resolve(true) }, 200);
     });
   });
-  return this.lineSpace();
+
+  return !use_glf ? this.lineSpace() : this;
 };
 
 /**


### PR DESCRIPTION
- Removed the 'async' statement on main image function, that statement is not necessary because the 'async' statement inside this function already does the job. 
    If we have the necessity of call the functions on printer.js as a Promise, we already have the promiseify.js loaded, so we just have to call 'this.printer.image().then()'. 
    Transform these functions with 'async' statement will break the functionality.

- Added a verification on what type of line feeding we require in the image() function on the printer.js file.
    Some Printers don't recognize the "lineSpace" function, these printers will always print "white lines" on the images even if we change the lineSpace to zero. 
    So I added a variable in the construction of the function that we should pass a boolean value when calling the function, this will choose what type of line feed We will use.

- Added the file .eslintrc.js for better javascript linting.