### PR TITLE
ci: migrate to Yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 
 before_install:
   - sudo apt-get install build-essential libudev-dev -y
-  - npm i -g npm@latest
 
 install:
-  - npm install -g node-pre-gyp-github && npm ci
+  - yarn global add node-pre-gyp-github && yarn install


### PR DESCRIPTION
Also the CircleCI setup is outdated and there is an issue with the used Node.js version.
Let's disable CircleCI and use Travis CI for all tests.