### PR TITLE
Replace unsupported nodejs version in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
 
 before_install:


### PR DESCRIPTION
According to the package.json, nodejs version 6 is not supported anyways. This breaks the travis build.
```
  "engines": {
    "node": ">=8.x"
  }
```

I replaced it with a newer version.