### PR TITLE
Fix Server bug: dest.end is not a function

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,9 @@ class Server extends tcp.Server {
     this.on('connection', this.request);
   }
   request(client){
-    client.pipe(this.device);
+    client.pipe(this.device, {
+      end: false
+    });
   }
 }
 


### PR DESCRIPTION
Adds `{ end: false }` to pipe method to not throw errors when connection closes.