### PR TITLE
Getting the image example more up to date & modifying the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const printer = new escpos.Printer(device, options);
 
 
 
-device.open(function(){
+device.open(function(error){
   printer
   .font('a')
   .align('ct')
@@ -111,9 +111,9 @@ const debugDevice = new escpos.Console();
 
 ### Methods
 
-#### open(function callback)
+#### open(function callback[err])
 
-Claims the current device USB (or other device type), if the printer is already in use by other process this will fail.
+Claims the current device USB (or other device type), if the printer is already in use by other process this will fail and return the error parameter.
 
 By default, the USB adapter will set the first printer found .
 
@@ -156,6 +156,21 @@ Prints raw text. Raises TextError exception.
 For the encode type, see the [iconv-lite wiki document](https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings). Escpos uses `iconv-lite` for encoding.
 
 If the type is undefined, the default type is GB18030.
+
+#### async image(imagePath, "density")
+
+Prints an image at a set density.
+
+Density consists of a character signaling the base density setting, `s` for single, `d` for double, followed by an integer for image sampling - `8` (8-bit) or `24`.
+
+```javascript
+printer.align('ct')
+       .image(image, 's8')
+       .then(() => { 
+          printer.cut()
+                 .close(); 
+       });
+```
 
 #### encode("encodeType")
 

--- a/examples/image.js
+++ b/examples/image.js
@@ -5,27 +5,25 @@ const escpos = require('../');
 const device  = new escpos.USB();
 const printer = new escpos.Printer(device);
 
-
 const tux = path.join(__dirname, 'tux.png');
 escpos.Image.load(tux, function(image){
 
   device.open(function(){
 
-    printer
-    .align('ct')
+    printer.align('ct');
 
-    .image(image, 's8')
-    .image(image, 'd8')
-    .image(image, 's24')
-    .image(image, 'd24')
+    printer.image(image, 's8');
+    printer.image(image, 'd8');
+    printer.image(image, 's24');
+    printer.image(image, 'd24');
     
-    .raster(image)
-    .raster(image, 'dw')
-    .raster(image, 'dh')
-    .raster(image, 'dwdh')
+    printer.raster(image);
+    printer.raster(image, 'dw');
+    printer.raster(image, 'dh');
+    printer.raster(image, 'dwdh');
 
-    .cut()
-    .close();
+    printer.cut()
+           .close();
   
   });
 

--- a/examples/image.js
+++ b/examples/image.js
@@ -10,21 +10,14 @@ escpos.Image.load(tux, function(image){
 
   device.open(function(){
 
-    printer.align('ct');
+    printer.align('ct')
+           .image(image, 's8')
+           .then(() => { 
+              printer.cut().close(); 
+           });
 
-    printer.image(image, 's8');
-    printer.image(image, 'd8');
-    printer.image(image, 's24');
-    printer.image(image, 'd24');
-    
-    printer.raster(image);
-    printer.raster(image, 'dw');
-    printer.raster(image, 'dh');
-    printer.raster(image, 'dwdh');
+    // OR non-async .raster(image, "mode") : printer.text("text").raster(image).cut().close();
 
-    printer.cut()
-           .close();
-  
   });
 
 });


### PR DESCRIPTION
I've recently had to work with a escpos printer and was grateful to find this library for Node. But I have noticed some missing information from the README and a example that does not work. This might not be the perfect fix so feel free to bounce back at me so we can refine this. Basically I've added a then() into the image example with the raster being as a possibility in a comment and added the image() function into the README, specifying that it is a async function, etc. + eidted in a error parameter into the open() function in README, since I noticed it does return it but nowhere is it stated. Thanks for you work!