### PR TITLE
fix process exit caused by uncaught exception when USB `claim` is called on a busy interface - V2

### DIFF
--- a/adapter/usb.js
+++ b/adapter/usb.js
@@ -108,28 +108,35 @@ USB.prototype.open = function (callback){
   this.device.interfaces.forEach(function(iface){
     (function(iface){
       iface.setAltSetting(iface.altSetting, function(){
-        // http://libusb.sourceforge.net/api-1.0/group__dev.html#gab14d11ed6eac7519bb94795659d2c971
-        // libusb_kernel_driver_active / libusb_attach_kernel_driver / libusb_detach_kernel_driver : "This functionality is not available on Windows."
-        if ("win32" !== os.platform()) {
-          if(iface.isKernelDriverActive()) {
-            try {
-              iface.detachKernelDriver();
-            } catch(e) {
-              console.error("[ERROR] Could not detatch kernel driver: %s", e)
+        try {
+          // http://libusb.sourceforge.net/api-1.0/group__dev.html#gab14d11ed6eac7519bb94795659d2c971
+          // libusb_kernel_driver_active / libusb_attach_kernel_driver / libusb_detach_kernel_driver : "This functionality is not available on Windows."
+          if ("win32" !== os.platform()) {
+            if(iface.isKernelDriverActive()) {
+              try {
+                iface.detachKernelDriver();
+              } catch(e) {
+                console.error("[ERROR] Could not detatch kernel driver: %s", e)
+              }
             }
           }
-        }
-        iface.claim(); // must be called before using any endpoints of this interface.
-        iface.endpoints.filter(function(endpoint){
-          if(endpoint.direction == 'out' && !self.endpoint) {
-            self.endpoint = endpoint;
+          iface.claim(); // must be called before using any endpoints of this interface.
+          iface.endpoints.filter(function(endpoint){
+            if(endpoint.direction == 'out' && !self.endpoint) {
+              self.endpoint = endpoint;
+            }
+          });
+          if(self.endpoint) {
+            self.emit('connect', self.device);
+            callback && callback(null, self);
+          } else if(++counter === this.device.interfaces.length && !self.endpoint){
+            callback && callback(new Error('Can not find endpoint from printer'));
           }
-        });
-        if(self.endpoint) {
-          self.emit('connect', self.device);
-          callback && callback(null, self);
-        } else if(++counter === this.device.interfaces.length && !self.endpoint){
-          callback && callback(new Error('Can not find endpoint from printer'));
+        } catch (e) {
+          // Try/Catch block to prevent process from exit due to uncaught exception.
+          // i.e LIBUSB_ERROR_ACCESS might be thrown by claim() if USB device is taken by another process
+          // example: MacOS Parallels
+          callback && callback(e);
         }
       });
     })(iface);


### PR DESCRIPTION
Propagate the fix to the V2 branch.
(cherry picked from commit db3ccc58b9b6f3e39085dae14d12c25a196166c6)