### PR TITLE
Fix cashdraw kick command to use single-byte hex

### DIFF
--- a/packages/printer/commands.js
+++ b/packages/printer/commands.js
@@ -71,8 +71,8 @@ _.HARDWARE = {
  * @type {Object}
  */
 _.CASH_DRAWER = {
-  CD_KICK_2: '\x1b\x70\x00\x19\xfa', // Sends a pulse to pin 2 []
-  CD_KICK_5: '\x1b\x70\x01\x19\xfa', // Sends a pulse to pin 5 []
+  CD_KICK_2: '\x1b\x70\x00\x19\x78', // Sends a pulse to pin 2 []
+  CD_KICK_5: '\x1b\x70\x01\x19\x78', // Sends a pulse to pin 5 []
 };
 
 /**


### PR DESCRIPTION
Maybe this wasn't tested properly at time of develoment but there is an issue with the cashdraw kick commands' hex codes. 

See this issue https://github.com/song940/node-escpos/issues/303

For some reason (beyond my knowledge of hex/ascii conversions stuff!) when a hex code from the extended ASCII table is used (i.e. beyond decimal value 127) NodeJS allocates two bytes for it in the `Buffer` object. The commands for cashdraw end with `\xfa` which corresponds to the decimal value 250. This results in two characters (bytes?) and ends up opening the cashdraw but also printing an extra character (usually a space, but I've also seen `||`) in the seubsequent print.

As the last part of the cashdraw command is only a time value (ie. 2ms x T2), and T2 can be anywhere between `00` and `FF` (see Controlling the Cash Drawer in [here](https://www.beaglehardware.com/howtoprogramcashdrawer.html)) I figured if we just use a value less than 127 it should 
a) still work, and
b) not cause an extra character in subsequent prints

I picked `\x78` which is 120 in decimal, so gives a T2 of 240ms before the next command can be issued.

I've tested this with an ESC/POS receipt printer and nicely fixes the problem.