### PR TITLE
Rare occasion where an exception "Cannot read property 'close' of null" when doing lots of rapid prints crashes the system

### DIFF
--- a/packages/serialport/index.js
+++ b/packages/serialport/index.js
@@ -1,27 +1,27 @@
-'use strict';
-const util          = require('util');
-const EventEmitter  = require('events');
+"use strict";
+const util = require("util");
+const EventEmitter = require("events");
 
 /**
  * SerialPort device
  * @param {[type]} port
  * @param {[type]} options
  */
-function Serial(port, options){
+function Serial(port, options) {
   var self = this;
-  options = options || { 
+  options = options || {
     baudRate: 9600,
-    autoOpen: false
+    autoOpen: false,
   };
-  const SerialPort = require('serialport');
+  const SerialPort = require("serialport");
   this.device = new SerialPort(port, options);
-  this.device.on('close', function() {
-    self.emit('disconnect', self.device);
+  this.device.on("close", function () {
+    self.emit("disconnect", self.device);
     self.device = null;
   });
   EventEmitter.call(this);
   return this;
-};
+}
 
 util.inherits(Serial, EventEmitter);
 
@@ -30,7 +30,7 @@ util.inherits(Serial, EventEmitter);
  * @param  {Function} callback
  * @return {[type]}
  */
-Serial.prototype.open = function(callback){
+Serial.prototype.open = function (callback) {
   this.device.open(callback);
   return this;
 };
@@ -41,7 +41,7 @@ Serial.prototype.open = function(callback){
  * @param  {Function} callback [description]
  * @return {[type]}            [description]
  */
-Serial.prototype.write = function(data, callback){
+Serial.prototype.write = function (data, callback) {
   this.device.write(data, callback);
   return this;
 };
@@ -52,29 +52,27 @@ Serial.prototype.write = function(data, callback){
  * @param  {int}      timeout   [allow manual timeout for emulated COM ports (bluetooth, ...)]
  * @return {[type]} [description]
  */
-Serial.prototype.close = function(callback, timeout) {
-
+Serial.prototype.close = function (callback, timeout) {
   var self = this;
 
-  this.device.drain(function() {
-
-    self.device.flush(function(err) {
-
-      setTimeout(function() {
-
-        err ? callback && callback(err, self.device) : self.device.close(function(err) {
-          self.device = null;
-          return callback && callback(err, self.device);
-        });
-
-      }, "number" === typeof timeout && 0 < timeout ? timeout : 0);
-
+  this.device.drain(function () {
+    self.device.flush(function (err) {
+      setTimeout(
+        function () {
+          err
+            ? callback && callback(err, self.device)
+            : self.device &&
+              self.device.close(function (err) {
+                self.device = null;
+                return callback && callback(err, self.device);
+              });
+        },
+        "number" === typeof timeout && 0 < timeout ? timeout : 0
+      );
     });
-
   });
 
   return this;
-
 };
 
 /**
@@ -82,8 +80,8 @@ Serial.prototype.close = function(callback, timeout) {
  * @param  {Function} callback
  * @return {Serial}
  */
-Serial.prototype.read = function(callback) {
-  this.device.on('data', function(data) {
+Serial.prototype.read = function (callback) {
+  this.device.on("data", function (data) {
     callback(data);
   });
   return this;

--- a/packages/serialport/index.js
+++ b/packages/serialport/index.js
@@ -1,27 +1,27 @@
-"use strict";
-const util = require("util");
-const EventEmitter = require("events");
+'use strict';
+const util          = require('util');
+const EventEmitter  = require('events');
 
 /**
  * SerialPort device
  * @param {[type]} port
  * @param {[type]} options
  */
-function Serial(port, options) {
+function Serial(port, options){
   var self = this;
-  options = options || {
+  options = options || { 
     baudRate: 9600,
-    autoOpen: false,
+    autoOpen: false
   };
-  const SerialPort = require("serialport");
+  const SerialPort = require('serialport');
   this.device = new SerialPort(port, options);
-  this.device.on("close", function () {
-    self.emit("disconnect", self.device);
+  this.device.on('close', function() {
+    self.emit('disconnect', self.device);
     self.device = null;
   });
   EventEmitter.call(this);
   return this;
-}
+};
 
 util.inherits(Serial, EventEmitter);
 
@@ -30,7 +30,7 @@ util.inherits(Serial, EventEmitter);
  * @param  {Function} callback
  * @return {[type]}
  */
-Serial.prototype.open = function (callback) {
+Serial.prototype.open = function(callback){
   this.device.open(callback);
   return this;
 };
@@ -41,7 +41,7 @@ Serial.prototype.open = function (callback) {
  * @param  {Function} callback [description]
  * @return {[type]}            [description]
  */
-Serial.prototype.write = function (data, callback) {
+Serial.prototype.write = function(data, callback){
   this.device.write(data, callback);
   return this;
 };
@@ -52,27 +52,29 @@ Serial.prototype.write = function (data, callback) {
  * @param  {int}      timeout   [allow manual timeout for emulated COM ports (bluetooth, ...)]
  * @return {[type]} [description]
  */
-Serial.prototype.close = function (callback, timeout) {
+Serial.prototype.close = function(callback, timeout) {
+
   var self = this;
 
-  this.device.drain(function () {
-    self.device.flush(function (err) {
-      setTimeout(
-        function () {
-          err
-            ? callback && callback(err, self.device)
-            : self.device &&
-              self.device.close(function (err) {
-                self.device = null;
-                return callback && callback(err, self.device);
-              });
-        },
-        "number" === typeof timeout && 0 < timeout ? timeout : 0
-      );
+  this.device.drain(function() {
+
+    self.device.flush(function(err) {
+
+      setTimeout(function() {
+
+        err ? callback && callback(err, self.device) : self.device && self.device.close(function(err) {
+          self.device = null;
+          return callback && callback(err, self.device);
+        });
+
+      }, "number" === typeof timeout && 0 < timeout ? timeout : 0);
+
     });
+
   });
 
   return this;
+
 };
 
 /**
@@ -80,8 +82,8 @@ Serial.prototype.close = function (callback, timeout) {
  * @param  {Function} callback
  * @return {Serial}
  */
-Serial.prototype.read = function (callback) {
-  this.device.on("data", function (data) {
+Serial.prototype.read = function(callback) {
+  this.device.on('data', function(data) {
     callback(data);
   });
   return this;


### PR DESCRIPTION
```js
Cannot read property 'close' of null
at Timeout._onTimeout (/opt/launcher/data/builds/_[3220dd6c](https://github.com/pos/mono-repo/-/commit/3220dd6cdfe8a76b52234fe85647d2532f20c7d3)_1267-rc8/gp-pos/node_modules/escpos-serialport/index.js:65:68)
at listOnTimeout (internal/timers.js:555:17)
at processTimers (internal/timers.js:498:7)
```