### PR TITLE
added STAR printer essential milestone and its example

### DIFF
--- a/examples/star_printer_index.js
+++ b/examples/star_printer_index.js
@@ -1,0 +1,27 @@
+'use strict';
+const escpos = require('..');
+
+// const device  = new escpos.USB(0x0416, 0x5011);
+// const device  = new escpos.RawBT();
+const device  = new escpos.Network('STARPrinterIPAddress');
+// const device  = new escpos.Serial('/dev/usb/lp0');
+const printer = new escpos.Printer(device);
+
+device.open(function(err){
+  printer
+  .font('a')
+  .align("STAR_CA")
+  .style('bu')
+  .size(1, 1)
+  .emphasize()
+  .text('The quick brown fox jumps over the lazy dog')
+  .cancelEmphasize()
+  .align("STAR_LA")
+  .text('敏捷的棕色狐狸跳过懒狗')
+  .align("STAR_RA")
+  .barcode('1234567', 'EAN8')
+  .qrimage('https://github.com/song940/node-escpos', function(err){
+    this.fullCut()
+    this.close();
+  });
+});

--- a/packages/printer/src/commands.ts
+++ b/packages/printer/src/commands.ts
@@ -88,6 +88,7 @@ export const PAPER = {
   PAPER_PART_CUT: '\x1d\x56\x01', // Partial cut paper
   PAPER_CUT_A: '\x1d\x56\x41', // Partial cut paper
   PAPER_CUT_B: '\x1d\x56\x42', // Partial cut paper
+  STAR_FULL_CUT: '\x1B\x64\x02' , // STAR printer - Full cut
 };
 
 /**
@@ -100,6 +101,8 @@ export const TEXT_FORMAT = {
   TXT_2HEIGHT: '\x1b\x21\x10', // Double height text
   TXT_2WIDTH: '\x1b\x21\x20', // Double width text
   TXT_4SQUARE: '\x1b\x21\x30', // Double width & height text
+  STAR_TXT_EMPHASIZED: '\x1B\x45', // STAR printer - Select emphasized printing
+  STAR_CANCEL_TXT_EMPHASIZED: '\x1B\x46', // STAR printer - Cancel emphasized printing
 
   TXT_CUSTOM_SIZE: function(width: number, height: number) { // other sizes
     width = width > 8 ? 8 : width;
@@ -155,6 +158,10 @@ export const TEXT_FORMAT = {
   TXT_ALIGN_LT: '\x1b\x61\x00', // Left justification
   TXT_ALIGN_CT: '\x1b\x61\x01', // Centering
   TXT_ALIGN_RT: '\x1b\x61\x02', // Right justification
+
+  STAR_TXT_ALIGN_LA: '\x1B\x1D\x61\x00', // STAR printer - Left alignment
+  STAR_TXT_ALIGN_CA: '\x1B\x1D\x61\x01', // STAR printer - Center alignment
+  STAR_TXT_ALIGN_RA: '\x1B\x1D\x61\x02', // STAR printer - Right alignment
 };
 
 /**

--- a/packages/printer/src/index.ts
+++ b/packages/printer/src/index.ts
@@ -901,6 +901,33 @@ export class Printer<AdapterCloseArgs extends []> extends EventEmitter {
       });
     });
   }
+
+  /**
+   * STAR printer - Paper cut instruction
+   * @return {[Printer]} printer  [the escpos printer instance]
+   */
+  starFullCut() {
+    this.buffer.write(_.PAPER.STAR_FULL_CUT);
+    return this;
+  };
+
+  /**
+   * STAR printer - Select emphasized printing
+   * @return {[Printer]} printer  [the escpos printer instance]
+   */
+  emphasize() {
+    this.buffer.write(_.TEXT_FORMAT.STAR_TXT_EMPHASIZED);
+    return this;
+  };
+
+  /**
+   * STAR printer - Cancel emphasized printing
+   * @return {[Printer]} printer  [the escpos printer instance]
+   */
+  cancelEmphasize() {
+    this.buffer.write(_.TEXT_FORMAT.STAR_CANCEL_TXT_EMPHASIZED);
+    return this;
+  }
 }
 
 export default Printer;


### PR DESCRIPTION
STAR printer works well with ESC/POS library but just needs some different commands.
I added some essential features to this PR with its example, which are all fully tested.
I would like to add more STAR printer features from this PR.
Here's the summary of features that I added below.
```
ESC d n
[Name] Paper cut instruction
[Code] ASCII ESC d n
Hexadecimal 1B 64 n
Decimal 27 100 n
[Defined Area] 0 ≤ n ≤ 3
48 ≤ n ≤ 51 (“0” ≤ n ≤ “3”)
[Initial Value] ---
[Function] This command executes the auto-cut according to the n specification, after printing data in the line buffer.
After auto-cutter is executed, the printer considers that position to be the top of the page.
```

```
ESC E
[Name] Select emphasized printing
[Code] ASCII ESC E
Hexadecimal 1B 45
Decimal 27 69
[Defined Area] ---
[Initial Value] Emphasized printing cancelled.
[Function] Specifies emphasized printing for subsequent data.
When in emphasized printing, data is printed in two passes.
This command is effective for both ANK characters and Kanji characters (prints with four passes for 2 pass
Kanji characters, and with 8 passes for 4 pass Kanji characters).
```

```
ESC F
[Name] Cancel emphasized printing
[Code] ASCII ESC F
Hexadecimal 1B 46
Decimal 27 70
[Defined Area] ---
[Initial Value] Emphasized printing cancelled.
[Function] Cancels emphasized printing for subsequent data.
```

```
ESC GS a n
[Name] Specify position alignment
[Code] ASCII ESC GS a n
Hexadecimal 1B 1D 61 n
Decimal 27 29 97 n
[Defined Area] 0 ≤ n ≤ 2
48 ≤ n ≤ 50 (“0” ≤ n ≤ “2”)
[Initial Value] n = 0
[Function] This specifies position alignment for all data in one line, in the set print region.
```



Reference
https://www.starmicronics.com/support/Mannualfolder/dot_star_cm_en.pdf