### PR TITLE
Fix code128 barcode string length calculation

### DIFF
--- a/packages/printer/src/utils.ts
+++ b/packages/printer/src/utils.ts
@@ -12,7 +12,8 @@ export function getParityBit(str: string) {
 }
 
 export function codeLength(str: string) {
-  let buff = Buffer.from((str.length).toString(16), 'hex');
+  const hex = Number(str.length).toString(16).padStart(2, '0')
+  let buff = Buffer.from(hex, 'hex');
   return buff.toString();
 }
 


### PR DESCRIPTION
When attempt to print Code128 barcode, where barcode content is less than 16 character, invalid single char hex character is returned and failed to be converted to buffer causing barcode failed to print,