### PR TITLE
device write string bugfix

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -60,7 +60,7 @@ export default class Network extends Adapter<[device: net.Socket]> {
     const handler: Function = (error?: Error | null) => {
       if (callback) callback(error ?? null);
     };
-    if (typeof data === 'string') this.device.write(data, handler);
+    if (typeof data === 'string') this.device.write(data, null, handler);
     else this.device.write(data, handler);
     return this;
   };


### PR DESCRIPTION
socket.write [documentation](https://nodejs.org/docs/latest-v16.x/api/net.html#socketwritedata-encoding-callback) describes that there are three params when writing a string:  socket.write(data[, encoding][, callback])
1. data <string> | <Buffer> | <Uint8Array>
2. encoding <string> **Only used when data is string**. Default: utf8.
3. callback <Function>