### PR TITLE
network socket write type fix

### DIFF
--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -60,7 +60,7 @@ export default class Network extends Adapter<[device: net.Socket]> {
     const handler: Function = (error?: Error | null) => {
       if (callback) callback(error ?? null);
     };
-    if (typeof data === 'string') this.device.write(data, null, handler);
+    if (typeof data === 'string') this.device.write(data, undefined, handler);
     else this.device.write(data, handler);
     return this;
   };


### PR DESCRIPTION
The language is TS so `null` value is not accepted but `undefined` is required.
Validated with `tsc` compiler.